### PR TITLE
Refine meta keywords and enable override

### DIFF
--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -53,6 +53,9 @@
                 (strpos(url()->current(), 'checkout') !== false ? $checkoutTitle : $genericTitle);
             $meta_description = $pageMeta ? $pageMeta->meta_description :
                 (strpos(url()->current(), 'checkout') !== false ? $checkoutDescription : $genericDescription);
+
+            $defaultKeywords = 'forfatterskolen, forfatterkurs, manusutvikling, manuskript, dikt, sakprosa, serieroman, krim, roman';
+            $meta_keywords = $pageMeta && $pageMeta->meta_keywords ? $pageMeta->meta_keywords : $defaultKeywords;
         ?>
 
         {{--@if ($pageMeta)--}}
@@ -82,7 +85,7 @@
 
         <!-- use meta title first before the title on the actual page added-->
         @yield('title')
-        <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
+        <meta name="keywords" content="{{ $meta_keywords }}">
         <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />

--- a/resources/views/frontend/partials/_meta.blade.php
+++ b/resources/views/frontend/partials/_meta.blade.php
@@ -12,6 +12,9 @@
         (strpos(url()->current(), 'checkout') !== false ? $checkoutTitle : $genericTitle);
     $meta_description = $pageMeta ? $pageMeta->meta_description :
         (strpos(url()->current(), 'checkout') !== false ? $checkoutDescription : $genericDescription);
+
+    $defaultKeywords = 'forfatterskolen, forfatterkurs, manusutvikling, manuskript, dikt, sakprosa, serieroman, krim, roman';
+    $meta_keywords = $pageMeta && $pageMeta->meta_keywords ? $pageMeta->meta_keywords : $defaultKeywords;
 ?>
 
 <meta property="og:title" content="{{ $meta_title }}">
@@ -37,7 +40,7 @@
     {{ $meta_title }}
 </title>
 
-<meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
+<meta name="keywords" content="{{ $meta_keywords }}">
 <meta name="nosnippets">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
 <meta name="csrf-token" content="{{ csrf_token() }}" />


### PR DESCRIPTION
## Summary
- replace misspelled static keywords with curated Norwegian list
- allow optional per-page override of keywords via PageMeta

## Testing
- `npm test` *(fails: Missing script)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dce0d660832db4327f82677b0fa2