### PR TITLE
Add alt text to frontend partial images

### DIFF
--- a/resources/views/frontend/partials/_learner_topbar.blade.php
+++ b/resources/views/frontend/partials/_learner_topbar.blade.php
@@ -19,7 +19,7 @@
 
         @if (Route::currentRouteName() === 'learner.invoice')
             <a href="#" data-toggle="modal" data-target="#redeemModal" class="redeem-gift-link">
-                <img src="{{ asset('images-new/icon/gift.png') }}">
+                <img src="{{ asset('images-new/icon/gift.png') }}" alt="Gaveikon">
             </a>
         @endif
         <div class="user-image-container d-inline-block">

--- a/resources/views/frontend/partials/assignment/_no_word_limit.blade.php
+++ b/resources/views/frontend/partials/assignment/_no_word_limit.blade.php
@@ -25,7 +25,7 @@
             <div class="assignment-container">
                 <div class="col-md-12 col-sm-12">
                     <h2>
-                        <img src="{{ asset('images-new/icon/assignment-file.png') }}">{{ $assignment->title }}
+                        <img src="{{ asset('images-new/icon/assignment-file.png') }}" alt="Oppgavefil ikon">{{ $assignment->title }}
                     </h2>
 
                     <p class="description-container">

--- a/resources/views/frontend/partials/assignment/_waiting_for_feedback.blade.php
+++ b/resources/views/frontend/partials/assignment/_waiting_for_feedback.blade.php
@@ -40,7 +40,7 @@
                 </div> <!-- end col-md col-sm -->
                 <div class="col-md-7 col-sm-12">
                     <h2>
-                        <img src="{{ asset('images-new/icon/assignment-file.png') }}">{{ $assignment->title }}
+                        <img src="{{ asset('images-new/icon/assignment-file.png') }}" alt="Oppgavefil ikon">{{ $assignment->title }}
                     </h2>
 
                     <p class="description-container">

--- a/resources/views/frontend/partials/footer-new.blade.php
+++ b/resources/views/frontend/partials/footer-new.blade.php
@@ -59,25 +59,25 @@
                 <li class="nav-item">
                     <a class="nav-link" href="https://twitter.com/Forfatterrektor" target="_blank">
                         <i class="sprite-social twitter-white"></i>
-                        {{--<img src="{{asset('images-new/social-icons/twitter-white.png')}}" class="social-image">--}}
+                        {{--<img src="{{asset('images-new/social-icons/twitter-white.png')}}" class="social-image" alt="Twitter">--}}
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://no.pinterest.com/forfatterskolen_norge/" target="_blank">
                         <i class="sprite-social pinterest-white"></i>
-                        {{--<img src="{{asset('images-new/social-icons/pinterest-white.png')}}" class="social-image">--}}
+                        {{--<img src="{{asset('images-new/social-icons/pinterest-white.png')}}" class="social-image" alt="Pinterest">--}}
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://www.instagram.com/forfatterskolen_norge/" target="_blank">
                         <i class="sprite-social instagram-white"></i>
-                        {{--<img src="{{asset('images-new/social-icons/instagram-white.png')}}" class="social-image">--}}
+                        {{--<img src="{{asset('images-new/social-icons/instagram-white.png')}}" class="social-image" alt="Instagram">--}}
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="https://www.facebook.com/bliforfatter/" target="_blank">
                         <i class="sprite-social facebook-white"></i>
-                        {{--<img src="{{asset('images-new/social-icons/facebook-white.png')}}" class="social-image">--}}
+                        {{--<img src="{{asset('images-new/social-icons/facebook-white.png')}}" class="social-image" alt="Facebook">--}}
                     </a>
                 </li>
             </ul>
@@ -88,7 +88,7 @@
         <div class="container">
             <div class="row justify-content-center text-center">
                 <div class="col-xl-3 col-lg-4 col-md-4">
-                    <img data-src="https://www.forfatterskolen.no/images-new/marker.png" alt="">
+                    <img data-src="https://www.forfatterskolen.no/images-new/marker.png" alt="Adresseikon">
                     <h2 class="mt-4">Adresse</h2>
                     <p class="mt-4">
                         Postboks 9233, 3028 Drammen
@@ -102,7 +102,7 @@
                     </p>
                 </div>
                 <div class="col-xl-3 col-lg-4 col-md-4">
-                    <img data-src="https://www.forfatterskolen.no/images-new/telephone.png" alt="">
+                    <img data-src="https://www.forfatterskolen.no/images-new/telephone.png" alt="Telefonikon">
                     <div class="mt-4 h2">Kontakt Telefon</div>
                     <p class="mt-4">
                         +47 411 23 555

--- a/resources/views/frontend/partials/footer.blade.php
+++ b/resources/views/frontend/partials/footer.blade.php
@@ -16,7 +16,7 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-md-4 text-center">
-					<a href="{{ url('') }}" class="footer-brand"><img src="{{asset('images/logo-footer.png')}}"></a>
+                                        <a href="{{ url('') }}" class="footer-brand"><img src="{{asset('images/logo-footer.png')}}" alt="Forfatterskolen-logo"></a>
 				</div>
 
 				<div class="col-md-4">

--- a/resources/views/frontend/partials/home-footer-new.blade.php
+++ b/resources/views/frontend/partials/home-footer-new.blade.php
@@ -94,8 +94,7 @@
     <div class="container">
         <div class="row mb-5">
             <div class="col-md-6">
-                <img data-src="https://www.forfatterskolen.no/{{'images-new/home/logo_2.png'}}" class="logo"
-                     alt="new footer logo">
+                <img data-src="https://www.forfatterskolen.no/{{'images-new/home/logo_2.png'}}" class="logo" alt="Forfatterskolen-logo">
             </div>
             <div class="col-md-6">
                 <div class="col-sm-4">

--- a/resources/views/frontend/partials/home-footer.blade.php
+++ b/resources/views/frontend/partials/home-footer.blade.php
@@ -19,8 +19,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-6 col-sm-7">
-                <img data-src="https://www.forfatterskolen.no/{{'images-new/home/logo_2.png'}}" class="logo"
-                     alt="small logo">
+                <img data-src="https://www.forfatterskolen.no/{{'images-new/home/logo_2.png'}}" class="logo" alt="Forfatterskolen-logo">
                 <p class="mt-5">
                     <i class="icons marker"></i><span class="font-montserrat-semibold text-uppercase">Adresse:</span>
                     <span class="font-montserrat-light">Lihagen 21, 3029 DRAMMEN</span>

--- a/resources/views/frontend/partials/learner-nav.blade.php
+++ b/resources/views/frontend/partials/learner-nav.blade.php
@@ -1,10 +1,10 @@
 <nav id="learnerNav" class="navbar navbar-light">
     <a class="navbar-brand" href="javascript:void(0)" style="cursor: default">{{--{{url('')}}--}}
-        <img data-src="https://www.forfatterskolen.no/images-new/logo11.png">
+        <img data-src="https://www.forfatterskolen.no/images-new/logo11.png" alt="Forfatterskolen-logo">
     </a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav">
-        {{--<img src="" alt="">--}}
+        {{--<img src="" alt="Menyikon">--}}
         <i></i>
     </button>
 
@@ -40,25 +40,25 @@
         <li class="nav-item">
             <a class="nav-link" href="https://twitter.com/Forfatterrektor" target="_blank">
                 <i class="sprite-social twitter"></i>
-                {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image" alt="Twitter">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://no.pinterest.com/forfatterskolen_norge/" target="_blank">
                 <i class="sprite-social pinterest"></i>
-                {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image" alt="Pinterest">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://www.instagram.com/forfatterskolen_norge/" target="_blank">
                 <i class="sprite-social instagram"></i>
-                {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image" alt="Instagram">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://www.facebook.com/bliforfatter/" target="_blank">
                 <i class="sprite-social facebook"></i>
-                {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image" alt="Facebook">--}}
             </a>
         </li>
         @if (Auth::guest())
@@ -160,11 +160,11 @@
 
 <div id="mobile-learner-menu" class="navbar navbar-light">
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavMobile">
-        <img src="" alt="">
+        <img src="" alt="Åpne meny">
     </button>
 
     <a class="navbar-brand mx-auto" href="{{url('')}}">
-        <img src="{{asset('images-new/logo.png')}}">
+        <img src="{{asset('images-new/logo.png')}}" alt="Forfatterskolen-logo">
     </a>
 </div>
 

--- a/resources/views/frontend/partials/navbar-new.blade.php
+++ b/resources/views/frontend/partials/navbar-new.blade.php
@@ -20,28 +20,28 @@
                 <a class="nav-link" href="https://twitter.com/Forfatterrektor" target="_blank"
                    title="View twitter page">
                     <i class="sprite-social twitter"></i>
-                    {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image">--}}
+                    {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image" alt="Twitter">--}}
                 </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://no.pinterest.com/forfatterskolen_norge/" target="_blank"
                    title="View pinterest page">
                     <i class="sprite-social pinterest"></i>
-                    {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image">--}}
+                    {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image" alt="Pinterest">--}}
                 </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://www.instagram.com/forfatterskolen_norge/" target="_blank"
                     title="View instagram page">
                     <i class="sprite-social instagram"></i>
-                    {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image">--}}
+                    {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image" alt="Instagram">--}}
                 </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="https://www.facebook.com/bliforfatter/" target="_blank"
                     title="View facebook page">
                     <i class="sprite-social facebook"></i>
-                    {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image">--}}
+                    {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image" alt="Facebook">--}}
                 </a>
             </li>
             @if (Auth::guest())

--- a/resources/views/frontend/partials/navbar.blade.php
+++ b/resources/views/frontend/partials/navbar.blade.php
@@ -13,7 +13,7 @@
 
 <nav class="navbar navbar-default">
   <div class="navbar-brand-container">
-    <a class="navbar-brand" href="{{url('')}}"><img src="{{asset('images/logo.png')}}"></a>
+    <a class="navbar-brand" href="{{url('')}}"><img src="{{asset('images/logo.png')}}" alt="Forfatterskolen-logo"></a>
   </div>
   <div class="container-fluid">
       <div class="navbar-header">

--- a/resources/views/frontend/partials/self-publishing-nav.blade.php
+++ b/resources/views/frontend/partials/self-publishing-nav.blade.php
@@ -1,10 +1,10 @@
 <nav id="learnerNav" class="navbar navbar-light">
     <a class="navbar-brand" href="javascript:void(0)" style="cursor: default">{{--{{url('')}}--}}
-        <img data-src="https://www.forfatterskolen.no/images-new/logo11.png">
+        <img data-src="https://www.forfatterskolen.no/images-new/logo11.png" alt="Forfatterskolen-logo">
     </a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNav">
-        {{--<img src="" alt="">--}}
+        {{--<img src="" alt="Menyikon">--}}
         <i></i>
     </button>
 
@@ -40,25 +40,25 @@
         <li class="nav-item">
             <a class="nav-link" href="https://twitter.com/Forfatterrektor" target="_blank">
                 <i class="sprite-social twitter"></i>
-                {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/twitter.png')}}" class="social-image" alt="Twitter">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://no.pinterest.com/forfatterskolen_norge/" target="_blank">
                 <i class="sprite-social pinterest"></i>
-                {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/pinterest.png')}}" class="social-image" alt="Pinterest">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://www.instagram.com/forfatterskolen_norge/" target="_blank">
                 <i class="sprite-social instagram"></i>
-                {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/instagram.png')}}" class="social-image" alt="Instagram">--}}
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="https://www.facebook.com/bliforfatter/" target="_blank">
                 <i class="sprite-social facebook"></i>
-                {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image">--}}
+                {{--<img src="{{asset('images-new/social-icons/facebook.png')}}" class="social-image" alt="Facebook">--}}
             </a>
         </li>
         @if (Auth::guest())
@@ -134,11 +134,11 @@
 
 <div id="mobile-learner-menu" class="navbar navbar-light">
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavMobile">
-        <img src="" alt="">
+        <img src="" alt="Åpne meny">
     </button>
 
     <a class="navbar-brand mx-auto" href="{{url('')}}">
-        <img src="{{asset('images-new/logo.png')}}">
+        <img src="{{asset('images-new/logo.png')}}" alt="Forfatterskolen-logo">
     </a>
 </div>
 


### PR DESCRIPTION
## Summary
- add descriptive alt text for logos, menu icons, and contact icons across frontend partials
- provide alt text for assignment file icons
- ensure commented-out social icons include alt attributes

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcdea8b8832d92727af05f290646