### PR TITLE
Localize frontend meta titles and descriptions

### DIFF
--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
         <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
@@ -42,12 +42,10 @@
         <?php
             $pageMeta = \App\PageMeta::where('url', url()->current())->first();
 
-            $checkoutTitle = 'Forfatterskolen checkout page where the users could place orders';
-            $checkoutDescription = 'The checkout page is displaying all the possible fields needed and payment options
-                 to choose from for the user and make it easier to order the item';
-            $genericTitle = 'Forfatterskolen page for author';
-            $genericDescription = 'This page belongs to forfatterskolen which would show some items useful for authors to
-            increase their knowledge';
+            $checkoutTitle = 'Forfatterskolens utsjekksside der brukerne kan legge inn bestillinger';
+            $checkoutDescription = 'Utsjekkssiden viser alle nødvendige felt og betalingsalternativer som gjør det enklere for brukeren å bestille varen';
+            $genericTitle = 'Forfatterskolens side for forfattere';
+            $genericDescription = 'Denne siden tilhører Forfatterskolen og viser innhold som hjelper forfattere å øke sin kunnskap';
 
             $meta_title = $pageMeta ? $pageMeta->meta_title :
                 (strpos(url()->current(), 'checkout') !== false ? $checkoutTitle : $genericTitle);

--- a/resources/views/frontend/partials/_meta.blade.php
+++ b/resources/views/frontend/partials/_meta.blade.php
@@ -1,12 +1,10 @@
 <?php
     $pageMeta = \App\PageMeta::where('url', url()->current())->first();
 
-    $checkoutTitle = 'Forfatterskolen checkout page where the users could place orders';
-    $checkoutDescription = 'The checkout page is displaying all the possible fields needed and payment options
-            to choose from for the user and make it easier to order the item';
-    $genericTitle = 'Forfatterskolen page for author';
-    $genericDescription = 'This page belongs to forfatterskolen which would show some items useful for authors to
-    increase their knowledge';
+    $checkoutTitle = 'Forfatterskolens utsjekksside der brukerne kan legge inn bestillinger';
+    $checkoutDescription = 'Utsjekkssiden viser alle nødvendige felt og betalingsalternativer som gjør det enklere for brukeren å bestille varen';
+    $genericTitle = 'Forfatterskolens side for forfattere';
+    $genericDescription = 'Denne siden tilhører Forfatterskolen og viser innhold som hjelper forfattere å øke sin kunnskap';
 
     $meta_title = $pageMeta ? $pageMeta->meta_title :
         (strpos(url()->current(), 'checkout') !== false ? $checkoutTitle : $genericTitle);


### PR DESCRIPTION
## Summary
- translate default checkout and generic metadata to Norwegian
- set HTML document language to Norwegian

## Testing
- `php -l resources/views/frontend/layout.blade.php`
- `php -l resources/views/frontend/partials/_meta.blade.php`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit not found)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcdd9954832d820ae768516b80b3