### PR TITLE
Use app locale for lang attribute and add hreflang variants

### DIFF
--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ app()->getLocale() }}">
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
-        <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+        <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
+        <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Summary
- use `app()->getLocale()` for the HTML `lang` attribute
- replace `x-default` alternate link with `hreflang="no"` and add English variant

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcd775fc832d961a3f00525ca21c