### PR TITLE
Remove nosnippets meta tags

### DIFF
--- a/resources/views/frontend/layout-self-publishing.blade.php
+++ b/resources/views/frontend/layout-self-publishing.blade.php
@@ -19,7 +19,6 @@
         <!-- use meta title first before the title on the actual page added-->
         @yield('title')
         <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
-        <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />
         <meta name="p:domain_verify" content="eca72f9965922b1f82c80a1ef6e62743"/>

--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -83,7 +83,6 @@
         <!-- use meta title first before the title on the actual page added-->
         @yield('title')
         <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
-        <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />
         <meta name="p:domain_verify" content="eca72f9965922b1f82c80a1ef6e62743"/>

--- a/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
+++ b/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
@@ -19,7 +19,6 @@
         <!-- use meta title first before the title on the actual page added-->
         @yield('title')
         <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
-        <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />
         <meta name="p:domain_verify" content="eca72f9965922b1f82c80a1ef6e62743"/>

--- a/resources/views/frontend/learner/self-publishing/layout.blade.php
+++ b/resources/views/frontend/learner/self-publishing/layout.blade.php
@@ -20,7 +20,6 @@
         <!-- use meta title first before the title on the actual page added-->
         @yield('title')
         <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
-        <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />
         <meta name="p:domain_verify" content="eca72f9965922b1f82c80a1ef6e62743"/>

--- a/resources/views/frontend/partials/_meta.blade.php
+++ b/resources/views/frontend/partials/_meta.blade.php
@@ -38,7 +38,6 @@
 </title>
 
 <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
-<meta name="nosnippets">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
 <meta name="csrf-token" content="{{ csrf_token() }}" />
 <meta name="p:domain_verify" content="eca72f9965922b1f82c80a1ef6e62743"/>


### PR DESCRIPTION
## Summary
- remove `nosnippets` meta tags from main and self-publishing layouts
- drop `nosnippets` meta in shared meta partial to permit search engine snippets

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dcdc7a48832da2473edab3b11136