### PR TITLE
Ensure hreflang tags include self links

### DIFF
--- a/resources/views/frontend/layout-self-publishing.blade.php
+++ b/resources/views/frontend/layout-self-publishing.blade.php
@@ -3,6 +3,7 @@
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
         <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+        <link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -4,6 +4,7 @@
         <link rel="manifest" href="{{ asset('manifest.json') }}">
         <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
         <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
+        <link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/resources/views/frontend/layouts/course-portal.blade.php
+++ b/resources/views/frontend/layouts/course-portal.blade.php
@@ -6,6 +6,7 @@
 
     <link rel="manifest" href="{{ asset('manifest.json') }}">
     <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+    <link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />
     <link rel="canonical" href="{{ url()->current() }}">
 
     <!-- Google Tag Manager -->

--- a/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
+++ b/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
@@ -3,6 +3,7 @@
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
         <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+        <link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/resources/views/frontend/learner/self-publishing/layout.blade.php
+++ b/resources/views/frontend/learner/self-publishing/layout.blade.php
@@ -5,6 +5,7 @@
         {{-- <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" /> --}}
         <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
         <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
+        <link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Summary
- add `<link rel="alternate" href="{{ url()->current() }}" hreflang="{{ app()->getLocale() }}" />` to each layout with hreflang tags so pages link to their own locale

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: GitHub credentials required)*

------
https://chatgpt.com/codex/tasks/task_e_68ada957d400832d939d8881a88d17cb