### PR TITLE
Ensure hreflang alternate links across layouts

### DIFF
--- a/resources/views/frontend/layout-self-publishing.blade.php
+++ b/resources/views/frontend/layout-self-publishing.blade.php
@@ -2,7 +2,8 @@
 <html lang="en">
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
-        <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+        <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
+        <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/resources/views/frontend/layouts/course-portal.blade.php
+++ b/resources/views/frontend/layouts/course-portal.blade.php
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="manifest" href="{{ asset('manifest.json') }}">
-    <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+    <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
+    <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
     <link rel="canonical" href="{{ url()->current() }}">
 
     <!-- Google Tag Manager -->

--- a/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
+++ b/resources/views/frontend/learner/self-publishing/layout-orig.blade.php
@@ -2,7 +2,8 @@
 <html lang="en">
     <head>
         <link rel="manifest" href="{{ asset('manifest.json') }}">
-        <link rel="alternate" href="{{ config('app.url') }}" hreflang="x-default" />
+        <link rel="alternate" href="{{ config('app.url') }}" hreflang="no" />
+        <link rel="alternate" href="{{ config('app.url') }}/en" hreflang="en" />
         <link rel="canonical" href="{{ url()->current() }}">
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Summary
- Add Norwegian and English `hreflang` alternate links to self-publishing layout
- Mirror bidirectional `hreflang` links in course portal layout
- Mirror bidirectional `hreflang` links in original self-publishing layout

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed, response 403)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ada9567b04832d93b795c912442440