### PR TITLE
Use Blade sections for page titles

### DIFF
--- a/resources/views/frontend/auth/login.blade.php
+++ b/resources/views/frontend/auth/login.blade.php
@@ -1,19 +1,17 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>
-@if(!Request::input('t'))
-Login 
-@elseif(Request::input('t') == 'register')
-Register
-@elseif(Request::input('t') == 'passwordreset')
-Password Reset
-@elseif(Request::input('t') == 'password-change')
-Password Change
-@endif
-&rsaquo; Forfatterskolen
-</title>
-@stop
+@php
+    if(!Request::input('t')) {
+        $pageTitle = 'Login';
+    } elseif(Request::input('t') == 'register') {
+        $pageTitle = 'Register';
+    } elseif(Request::input('t') == 'passwordreset') {
+        $pageTitle = 'Password Reset';
+    } elseif(Request::input('t') == 'password-change') {
+        $pageTitle = 'Password Change';
+    }
+@endphp
+@section('title', $pageTitle . ' &rsaquo; Forfatterskolen')
 
 @section('styles')
 <style>

--- a/resources/views/frontend/auth/login11162023.blade.php
+++ b/resources/views/frontend/auth/login11162023.blade.php
@@ -1,19 +1,17 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>
-@if(!Request::input('t'))
-Login 
-@elseif(Request::input('t') == 'register')
-Register
-@elseif(Request::input('t') == 'passwordreset')
-Password Reset
-@elseif(Request::input('t') == 'password-change')
-Password Change
-@endif
-&rsaquo; Forfatterskolen
-</title>
-@stop
+@php
+    if(!Request::input('t')) {
+        $pageTitle = 'Login';
+    } elseif(Request::input('t') == 'register') {
+        $pageTitle = 'Register';
+    } elseif(Request::input('t') == 'passwordreset') {
+        $pageTitle = 'Password Reset';
+    } elseif(Request::input('t') == 'password-change') {
+        $pageTitle = 'Password Change';
+    }
+@endphp
+@section('title', $pageTitle . ' &rsaquo; Forfatterskolen')
 
 @section('styles')
 <style>

--- a/resources/views/frontend/auth/passwordreset.blade.php
+++ b/resources/views/frontend/auth/passwordreset.blade.php
@@ -1,17 +1,15 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>
-@if(!Request::input('t'))
-Login 
-@elseif(Request::input('t') == 'register')
-Register
-@elseif(Request::input('t') == 'passwordreset')
-Password Reset
-@endif
-&rsaquo; Forfatterskolen
-</title>
-@stop
+@php
+    if(!Request::input('t')) {
+        $pageTitle = 'Login';
+    } elseif(Request::input('t') == 'register') {
+        $pageTitle = 'Register';
+    } elseif(Request::input('t') == 'passwordreset') {
+        $pageTitle = 'Password Reset';
+    }
+@endphp
+@section('title', $pageTitle . ' &rsaquo; Forfatterskolen')
 
 @section('content')
 <div class="container login-container">

--- a/resources/views/frontend/auth/self-publishing-login.blade.php
+++ b/resources/views/frontend/auth/self-publishing-login.blade.php
@@ -1,10 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>
-	Login &rsaquo; Forfatterskolen
-</title>
-@stop
+@section('title', 'Login &rsaquo; Forfatterskolen')
 
 @section('content')
 <div class="login-container" data-bg="https://www.forfatterskolen.no/images-new/login/login-bg.jpg">

--- a/resources/views/frontend/barn.blade.php
+++ b/resources/views/frontend/barn.blade.php
@@ -1,16 +1,9 @@
 @extends('frontend.layout')
 
-@section('title')
-    <?php
+@php
     $pageMeta = \App\PageMeta::where('url', url()->current())->first();
-    ?>
-
-    @if ($pageMeta)
-        <title>{{ $pageMeta->meta_title }}</title>
-    @else
-        <title>Reprise: Slik forløser du ditt kreative potensial</title>
-    @endif
-@stop
+@endphp
+@section('title', $pageMeta->meta_title ?? 'Reprise: Slik forløser du ditt kreative potensial')
 
 @section('content')
 

--- a/resources/views/frontend/blog-new.blade.php
+++ b/resources/views/frontend/blog-new.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Blog</title>
-@stop
+@section('title', "Forfatterskolen Blog")
 
 @section('content')
 

--- a/resources/views/frontend/blog-read.blade.php
+++ b/resources/views/frontend/blog-read.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $blog->title }}</title>
-@stop
+@section('title', $blog->title)
 
 @section('metas')
     <meta property="og:url"           content="{{ route('front.read-blog', $blog->id) }}" />

--- a/resources/views/frontend/blog.blade.php
+++ b/resources/views/frontend/blog.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen Blog</title>
-@stop
+@section('title', "Forfatterskolen Blog")
 
 @section('content')
 

--- a/resources/views/frontend/chat/index.blade.php
+++ b/resources/views/frontend/chat/index.blade.php
@@ -1,10 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>
-        Chat
-    </title>
-@stop
+@section('title', 'Chat')
 
 @section('styles')
 <style>

--- a/resources/views/frontend/children.blade.php
+++ b/resources/views/frontend/children.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>SOS Children</title>
-@stop
+@section('title', "SOS Children")
 
 @section('content')
     <div class="container" id="children-container">

--- a/resources/views/frontend/coaching-timer-checkout-orig.blade.php
+++ b/resources/views/frontend/coaching-timer-checkout-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     @if(Session::has('compute_manuscript'))

--- a/resources/views/frontend/coaching-timer-checkout.blade.php
+++ b/resources/views/frontend/coaching-timer-checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     @if(Session::has('compute_manuscript'))

--- a/resources/views/frontend/coaching-timer-checkout12202023.blade.php
+++ b/resources/views/frontend/coaching-timer-checkout12202023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     @if(Session::has('compute_manuscript'))

--- a/resources/views/frontend/coaching-timer-login.blade.php
+++ b/resources/views/frontend/coaching-timer-login.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="global-checkout-page" id="app-container">

--- a/resources/views/frontend/coaching-timer.blade.php
+++ b/resources/views/frontend/coaching-timer.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Coaching Timer</title>
-@stop
+@section('title', "Forfatterskolen Coaching Timer")
 
 @section('content')
 

--- a/resources/views/frontend/coaching-timer12182023.blade.php
+++ b/resources/views/frontend/coaching-timer12182023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Coaching Timer</title>
-@stop
+@section('title', "Forfatterskolen Coaching Timer")
 
 @section('content')
 

--- a/resources/views/frontend/competition.blade.php
+++ b/resources/views/frontend/competition.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css">

--- a/resources/views/frontend/competition/innlevering.blade.php
+++ b/resources/views/frontend/competition/innlevering.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="checkout-page">

--- a/resources/views/frontend/competition/thank-you.blade.php
+++ b/resources/views/frontend/competition/thank-you.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="thank-you-page">

--- a/resources/views/frontend/contact-us.blade.php
+++ b/resources/views/frontend/contact-us.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen &rsaquo; Kontakt Oss</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Kontakt Oss")
 
 @section('content')
 <div class="contact-page-new">

--- a/resources/views/frontend/contact-us100623.blade.php
+++ b/resources/views/frontend/contact-us100623.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen &rsaquo; Kontakt Oss</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Kontakt Oss")
 
 @section('content')
     <div class="contact-page" >

--- a/resources/views/frontend/copy-editing.blade.php
+++ b/resources/views/frontend/copy-editing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen Copy Editing</title>
-@stop
+@section('title', "Forfatterskolen Copy Editing")
 
 @section('content')
 

--- a/resources/views/frontend/correction.blade.php
+++ b/resources/views/frontend/correction.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen Copy Editing</title>
-@stop
+@section('title', "Forfatterskolen Copy Editing")
 
 @section('content')
 

--- a/resources/views/frontend/course/application-thankyou.blade.php
+++ b/resources/views/frontend/course/application-thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="thank-you-page">

--- a/resources/views/frontend/course/application.blade.php
+++ b/resources/views/frontend/course/application.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>{{$course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $course->title . " &rsaquo; Forfatterskolen")
 
 @section('content')
 @php

--- a/resources/views/frontend/course/index.blade.php
+++ b/resources/views/frontend/course/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Courses &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Courses &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="course-page">

--- a/resources/views/frontend/course/show-orig.blade.php
+++ b/resources/views/frontend/course/show-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>{{$course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $course->title . " &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="container course-details-container">

--- a/resources/views/frontend/course/show.blade.php
+++ b/resources/views/frontend/course/show.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>{{$course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $course->title . " &rsaquo; Forfatterskolen")
 
 @section('metas')
 	<meta property="og:title" content="{{ $course->meta_title }}">
@@ -23,9 +21,6 @@
 	<meta name="twitter:description" content="{{ $course->meta_description }}" />
 	<meta property="fb:app_id" content="300010277156315" />
 
-	<title>
-		{{ $course->meta_title }}
-	</title>
 @stop
 
 @section('styles')

--- a/resources/views/frontend/email-tracking.blade.php
+++ b/resources/views/frontend/email-tracking.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="thank-you-page" data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png">

--- a/resources/views/frontend/faq.blade.php
+++ b/resources/views/frontend/faq.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen &rsaquo; FAQ</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; FAQ")
 
 @section('content')
 

--- a/resources/views/frontend/free-webinar-new.blade.php
+++ b/resources/views/frontend/free-webinar-new.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Free Webinar &rsaquo; {{ $freeWebinar->title }}</title>
-@stop
+@section('title', 'Free Webinar &rsaquo; ' . $freeWebinar->title)
 
 @section('styles')
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Oswald" />

--- a/resources/views/frontend/free-webinar-success-orig.blade.php
+++ b/resources/views/frontend/free-webinar-success-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Thank You for Subscribing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You for Subscribing &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="container">

--- a/resources/views/frontend/free-webinar-success.blade.php
+++ b/resources/views/frontend/free-webinar-success.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Thank You for Subscribing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You for Subscribing &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="free-webinar-thanks-page">

--- a/resources/views/frontend/free-webinar.blade.php
+++ b/resources/views/frontend/free-webinar.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Free Webinar &rsaquo; {{ $freeWebinar->title }}</title>
-@stop
+@section('title', 'Free Webinar &rsaquo; ' . $freeWebinar->title)
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('css/free-webinar.css?v='.time()) }}">

--- a/resources/views/frontend/free-webinar12272023.blade.php
+++ b/resources/views/frontend/free-webinar12272023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Free Webinar &rsaquo; {{ $freeWebinar->title }}</title>
-@stop
+@section('title', 'Free Webinar &rsaquo; ' . $freeWebinar->title)
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('css/free-webinar.css?v='.time()) }}">

--- a/resources/views/frontend/gift-cards.blade.php
+++ b/resources/views/frontend/gift-cards.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Gift Cards &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Gift Cards &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/gift/course-checkout.blade.php
+++ b/resources/views/frontend/gift/course-checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/gift/redeem.blade.php
+++ b/resources/views/frontend/gift/redeem.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen</title>
-@stop
+@section('title', "Forfatterskolen")
 
 @section('content')
     <div class="login-container" data-bg="https://www.forfatterskolen.no/images-new/login/login-bg.jpg">

--- a/resources/views/frontend/gift/shop-manuscript-checkout.blade.php
+++ b/resources/views/frontend/gift/shop-manuscript-checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/gift/thankyou.blade.php
+++ b/resources/views/frontend/gift/thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="thank-you-page" data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png">

--- a/resources/views/frontend/gro-dahle.blade.php
+++ b/resources/views/frontend/gro-dahle.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Gro Dahle Page</title>
-@stop
+@section('title', "Gro Dahle Page")
 
 @section('content')
 

--- a/resources/views/frontend/henrik-langeland.blade.php
+++ b/resources/views/frontend/henrik-langeland.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Henrik Langeland Page</title>
-@stop
+@section('title', "Henrik Langeland Page")
 
 @section('content')
 

--- a/resources/views/frontend/here-i-am.blade.php
+++ b/resources/views/frontend/here-i-am.blade.php
@@ -1,16 +1,9 @@
 @extends('frontend.layout')
 
-@section('title')
-    <?php
+@php
     $pageMeta = \App\PageMeta::where('url', url()->current())->first();
-    ?>
-
-    @if ($pageMeta)
-        <title>{{ $pageMeta->meta_title }}</title>
-    @else
-        <title>Reprise: Slik skriver du et førsteutkast</title>
-    @endif
-@stop
+@endphp
+@section('title', $pageMeta->meta_title ?? 'Reprise: Slik skriver du et førsteutkast')
 
 @section('styles')
     <style>

--- a/resources/views/frontend/home-09212021.blade.php
+++ b/resources/views/frontend/home-09212021.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen – Din litterære familie. Skrivekurs for deg</title>
-@stop
+@section('title', "Forfatterskolen – Din litterære familie. Skrivekurs for deg")
 
 @section('styles')
     <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css"

--- a/resources/views/frontend/home-new.blade.php
+++ b/resources/views/frontend/home-new.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen – Din litterære familie. Skrivekurs for deg</title>
-@stop
+@section('title', "Forfatterskolen – Din litterære familie. Skrivekurs for deg")
 
 @section('styles')
     <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css"

--- a/resources/views/frontend/home-orig.blade.php
+++ b/resources/views/frontend/home-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen</title>
-@stop
+@section('title', "Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css">

--- a/resources/views/frontend/home.blade.php
+++ b/resources/views/frontend/home.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen – Din litterære familie. Skrivekurs for deg</title>
-@stop
+@section('title', "Forfatterskolen – Din litterære familie. Skrivekurs for deg")
 
 @section('styles')
     <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css"

--- a/resources/views/frontend/layout-self-publishing.blade.php
+++ b/resources/views/frontend/layout-self-publishing.blade.php
@@ -17,7 +17,7 @@
         <link rel="stylesheet" href="{{asset('css/self-publishing.css?v='.time())}}">
 
         <!-- use meta title first before the title on the actual page added-->
-        @yield('title')
+        <title>@yield('title')</title>
         <meta name="keywords" content="forfatterskolen, forfatter, kurs, manusutvikling, manus, manuskript, kikt, sakprosa, serieroman, krim, roman">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">
         <meta name="csrf-token" content="{{ csrf_token() }}" />

--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -77,13 +77,8 @@
             <meta name="twitter:description" content="{{ $meta_description }}" />
             <meta property="fb:app_id" content="300010277156315" />
 
-            <title>
-                {{ $meta_title }}
-            </title>
+            <title>@yield('title')</title>
         {{--@endif--}}
-
-        <!-- use meta title first before the title on the actual page added-->
-        @yield('title')
         <meta name="keywords" content="{{ $meta_keywords }}">
         <meta name="nosnippets">
         <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no">

--- a/resources/views/frontend/learner/assignment-orig.blade.php
+++ b/resources/views/frontend/learner/assignment-orig.blade.php
@@ -4,9 +4,7 @@
 	<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
 @stop
 
-@section('title')
-<title>Assignments &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Assignments &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/assignment.blade.php
+++ b/resources/views/frontend/learner/assignment.blade.php
@@ -30,9 +30,7 @@
 	</style>
 @stop
 
-@section('title')
-<title>Assignments &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Assignments &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/assignment10172023.blade.php
+++ b/resources/views/frontend/learner/assignment10172023.blade.php
@@ -30,9 +30,7 @@
 	</style>
 @stop
 
-@section('title')
-<title>Assignments &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Assignments &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/assignmentShow.blade.php
+++ b/resources/views/frontend/learner/assignmentShow.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>{{ $assignment->title }} &rsaquo; Assignments &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $assignment->title  . " &rsaquo; Assignments &rsaquo; Forfatterskolen")
 
 
 @section('content')

--- a/resources/views/frontend/learner/calendar.blade.php
+++ b/resources/views/frontend/learner/calendar.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Calendar &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Calendar &rsaquo; Forfatterskolen")
 
 @section('styles')
 <link rel="stylesheet" href="{{asset('bootstrap-calendar/css/calendar.min.css')}}">

--- a/resources/views/frontend/learner/competition.blade.php
+++ b/resources/views/frontend/learner/competition.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Konkurranser &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Konkurranser &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container learner-competition">

--- a/resources/views/frontend/learner/course-webinar.blade.php
+++ b/resources/views/frontend/learner/course-webinar.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Mine Webinar &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Webinar &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container learner-webinar-page learner-course-webinar-page">

--- a/resources/views/frontend/learner/course-webinar12112023.blade.php
+++ b/resources/views/frontend/learner/course-webinar12112023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Mine Webinar &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Webinar &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container learner-webinar-page">

--- a/resources/views/frontend/learner/course.blade.php
+++ b/resources/views/frontend/learner/course.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Mine Kurs &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Kurs &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.my-course') }} @stop
 

--- a/resources/views/frontend/learner/course11302023.blade.php
+++ b/resources/views/frontend/learner/course11302023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Mine Kurs &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Kurs &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.my-course') }} @stop
 

--- a/resources/views/frontend/learner/course_show.blade.php
+++ b/resources/views/frontend/learner/course_show.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>{{$courseTaken->package->course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $courseTaken->package->course->title . " &rsaquo; Forfatterskolen")
 
 
 @section('content')

--- a/resources/views/frontend/learner/dashboard.blade.php
+++ b/resources/views/frontend/learner/dashboard.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Dashboard &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Dashboard &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/resources/views/frontend/learner/dashboard11242023.blade.php
+++ b/resources/views/frontend/learner/dashboard11242023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Dashboard &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Dashboard &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/resources/views/frontend/learner/groupShow.blade.php
+++ b/resources/views/frontend/learner/groupShow.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>{{ $group->title }} &rsaquo; Assignments &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $group->title  . " &rsaquo; Assignments &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/invoice-orig.blade.php
+++ b/resources/views/frontend/learner/invoice-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Invoices &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invoices &rsaquo; Forfatterskolen")
 
 
 @section('content')

--- a/resources/views/frontend/learner/invoice.blade.php
+++ b/resources/views/frontend/learner/invoice.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Invoices &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invoices &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.my-invoice') }} @stop
 @section('styles')

--- a/resources/views/frontend/learner/invoice12132023.blade.php
+++ b/resources/views/frontend/learner/invoice12132023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Invoices &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invoices &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.my-invoice') }} @stop
 @section('styles')

--- a/resources/views/frontend/learner/invoiceShow.blade.php
+++ b/resources/views/frontend/learner/invoiceShow.blade.php
@@ -17,9 +17,7 @@ else :
 endif;
 ?>
 
-@section('title')
-<title>Faktura #{{$fikenInvoice->invoiceNumber}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', 'Faktura #' . $fikenInvoice->invoiceNumber . ' &rsaquo; Forfatterskolen')
 
 
 @section('content')

--- a/resources/views/frontend/learner/lesson_show.blade.php
+++ b/resources/views/frontend/learner/lesson_show.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title> {{$lesson->title}} &rsaquo; {{$lesson->course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $lesson->title . " &rsaquo; {{$lesson->course->title}} &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/lesson_show10132021.blade.php
+++ b/resources/views/frontend/learner/lesson_show10132021.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title> {{$lesson->title}} &rsaquo; {{$lesson->course->title}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $lesson->title . " &rsaquo; {{$lesson->course->title}} &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/manuscriptShow.blade.php
+++ b/resources/views/frontend/learner/manuscriptShow.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Manuscript for course {{ $manuscript->courseTaken->package->course->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', 'Manuscript for course ' . $manuscript->courseTaken->package->course->title . ' &rsaquo; Forfatterskolen')
 
 
 @section('content')

--- a/resources/views/frontend/learner/notifications.blade.php
+++ b/resources/views/frontend/learner/notifications.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Notifications &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Notifications &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="account-container">

--- a/resources/views/frontend/learner/pilot-reader/account/index.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/account/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Preferences &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Preferences &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/account/reader-profile.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/account/reader-profile.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Preferences &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Preferences &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/author-book-chapter.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-chapter.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }}, Chapter &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . ", Chapter &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">

--- a/resources/views/frontend/learner/pilot-reader/author-book-import.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-import.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }}, Chapter &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . ", Chapter &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">

--- a/resources/views/frontend/learner/pilot-reader/author-book-invitation.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-invitation.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} Invitation &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " Invitation &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css" />

--- a/resources/views/frontend/learner/pilot-reader/author-book-show.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-show.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " &rsaquo; Forfatterskolen")
 
 @section('heading') My Books @stop
 

--- a/resources/views/frontend/learner/pilot-reader/author-book-view-chapter.blade-orig.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-view-chapter.blade-orig.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }}, {{ $chapter->title ? $chapter->title : 'Chapter '.$key }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . ", {{ $chapter->title ? $chapter->title : 'Chapter '.$key }} &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/pilot-reader/author-book-view-chapter.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-book-view-chapter.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }}, {{ $chapter->title ? $chapter->title : \App\Http\FrontendHelpers::getChapterTitle($book, $chapter->id)}} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . ", {{ $chapter->title ? $chapter->title : \App\Http\FrontendHelpers::getChapterTitle($book, $chapter->id)}} &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/pilot-reader/author-create-book.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-create-book.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>New Book &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "New Book &rsaquo; Forfatterskolen")
 
 @section('heading') New Book @stop
 

--- a/resources/views/frontend/learner/pilot-reader/author-dashboard.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/author-dashboard.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Book Author &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Book Author &rsaquo; Forfatterskolen")
 
 @section('heading') My Books @stop
 

--- a/resources/views/frontend/learner/pilot-reader/book-settings.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/book-settings.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} Settings &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " Settings &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css">

--- a/resources/views/frontend/learner/pilot-reader/feedback-list.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/feedback-list.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " &rsaquo; Forfatterskolen")
 
 @section('heading') My Books @stop
 

--- a/resources/views/frontend/learner/pilot-reader/invitations/accepted.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/invitations/accepted.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Declined &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Declined &rsaquo; Forfatterskolen")
 
 @section('heading') Invitation Declined @stop
 

--- a/resources/views/frontend/learner/pilot-reader/invitations/cancelled.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/invitations/cancelled.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Declined &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Declined &rsaquo; Forfatterskolen")
 
 @section('heading') Invitation Cancelled @stop
 

--- a/resources/views/frontend/learner/pilot-reader/invitations/decline.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/invitations/decline.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Declined &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Declined &rsaquo; Forfatterskolen")
 
 @section('heading') Invitation Declined @stop
 

--- a/resources/views/frontend/learner/pilot-reader/private-groups/discussion.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/discussion.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $page_title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $page_title  . " &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/index.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Private Groups &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Private Groups &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/invitations/accepted.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/invitations/accepted.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Accepted &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Accepted &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="account-container">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/invitations/cancelled.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/invitations/cancelled.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Cancelled &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Cancelled &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="account-container">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/invitations/decline.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/invitations/decline.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Declined &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Declined &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="account-container">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/invitations/invalid.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/invitations/invalid.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Invitation Invalid &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Invitation Invalid &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="account-container">

--- a/resources/views/frontend/learner/pilot-reader/private-groups/layout.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/private-groups/layout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $page_title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $page_title  . " &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css">

--- a/resources/views/frontend/learner/pilot-reader/reader-directory/about.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/reader-directory/about.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>About Reader Directory&rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "About Reader Directory&rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/reader-directory/index.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/reader-directory/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Reader Directory &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Reader Directory &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="{{ asset('js/toastr/toastr.min.css') }}">

--- a/resources/views/frontend/learner/pilot-reader/reader-directory/received-query.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/reader-directory/received-query.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Received Queries &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Received Queries &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css" integrity="sha384-EkHEUZ6lErauT712zSr0DZ2uuCmi3DoQj6ecNdHQXpMpFNGAQ48WjfXCE5n20W+R" crossorigin="anonymous">

--- a/resources/views/frontend/learner/pilot-reader/reader-directory/sent-query.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/reader-directory/sent-query.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Sent Queries &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Sent Queries &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css" integrity="sha384-EkHEUZ6lErauT712zSr0DZ2uuCmi3DoQj6ecNdHQXpMpFNGAQ48WjfXCE5n20W+R" crossorigin="anonymous">

--- a/resources/views/frontend/learner/pilot-reader/reader-feedback-list.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/reader-feedback-list.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " &rsaquo; Forfatterskolen")
 
 @section('heading') My Books @stop
 

--- a/resources/views/frontend/learner/pilot-reader/track-readers.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/track-readers.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} Track Readers &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " Track Readers &rsaquo; Forfatterskolen")
 
 @section('heading') Track Readers @stop
 

--- a/resources/views/frontend/learner/pilot-reader/viewer-feedback-list.blade.php
+++ b/resources/views/frontend/learner/pilot-reader/viewer-feedback-list.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $book->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $book->title  . " &rsaquo; Forfatterskolen")
 
 @section('heading') My Books @stop
 

--- a/resources/views/frontend/learner/private-message.blade.php
+++ b/resources/views/frontend/learner/private-message.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Mesages &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mesages &rsaquo; Forfatterskolen")
 
 @section('heading') Private beskjeder @stop
 

--- a/resources/views/frontend/learner/profile-orig.blade.php
+++ b/resources/views/frontend/learner/profile-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Profile &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Profile &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-confirm/3.3.0/jquery-confirm.min.css">

--- a/resources/views/frontend/learner/profile.blade.php
+++ b/resources/views/frontend/learner/profile.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Profile &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Profile &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-confirm/3.3.0/jquery-confirm.min.css">

--- a/resources/views/frontend/learner/publishing.blade.php
+++ b/resources/views/frontend/learner/publishing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Publishers House &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Publishers House &rsaquo; Forfatterskolen")
 
 @section('heading') Forlagsliste @stop
 

--- a/resources/views/frontend/learner/search.blade.php
+++ b/resources/views/frontend/learner/search.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Mine Kurs &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Kurs &rsaquo; Forfatterskolen")
 
 @section('heading') Search @stop
 

--- a/resources/views/frontend/learner/self-publishing/book-for-sale.blade.php
+++ b/resources/views/frontend/learner/self-publishing/book-for-sale.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Sales &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Sales &rsaquo; Forfatterskolen")
 
 @section('styles')
 <style>

--- a/resources/views/frontend/learner/self-publishing/copy-editing.blade.php
+++ b/resources/views/frontend/learner/self-publishing/copy-editing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/correction.blade.php
+++ b/resources/views/frontend/learner/self-publishing/correction.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/cover-details.blade.php
+++ b/resources/views/frontend/learner/self-publishing/cover-details.blade.php
@@ -9,9 +9,7 @@
     </style>
 @stop
 
-@section('title')
-    <title>Cover Details &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cover Details &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/learner/self-publishing/cover.blade.php
+++ b/resources/views/frontend/learner/self-publishing/cover.blade.php
@@ -4,9 +4,7 @@
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
 @stop
 
-@section('title')
-    <title>Cover &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cover &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/dashboard.blade.php
+++ b/resources/views/frontend/learner/self-publishing/dashboard.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-<title>Dashboard &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Dashboard &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/resources/views/frontend/learner/self-publishing/marketing.blade.php
+++ b/resources/views/frontend/learner/self-publishing/marketing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Marketing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Marketing &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/order/checkout.blade.php
+++ b/resources/views/frontend/learner/self-publishing/order/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container order-container">

--- a/resources/views/frontend/learner/self-publishing/order/index.blade.php
+++ b/resources/views/frontend/learner/self-publishing/order/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/page-format-details.blade.php
+++ b/resources/views/frontend/learner/self-publishing/page-format-details.blade.php
@@ -9,9 +9,7 @@
     </style>
 @stop
 
-@section('title')
-    <title>Page Format Details &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Page Format Details &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/page-format.blade.php
+++ b/resources/views/frontend/learner/self-publishing/page-format.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Cover &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cover &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-orig.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Marketing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Marketing &rsaquo; Forfatterskolen")
 
 @section('styles')
 <style>

--- a/resources/views/frontend/learner/self-publishing/progress-plan-step.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-step.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Progress Plan Step &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Progress Plan Step &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/audio.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/audio.blade.php
@@ -4,9 +4,7 @@
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
 @stop
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/copy-editing.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/copy-editing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/correction.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/correction.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/cover.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/cover.blade.php
@@ -4,9 +4,7 @@
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
 @stop
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/e-book.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/e-book.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/manuscripts.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/manuscripts.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Progress Plan Step &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Progress Plan Step &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/print.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/print.blade.php
@@ -9,9 +9,7 @@
     </style>
 @stop
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan-steps/type_setting.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan-steps/type_setting.blade.php
@@ -4,9 +4,7 @@
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">
 @stop
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/progress-plan.blade.php
+++ b/resources/views/frontend/learner/self-publishing/progress-plan.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Progress Plan &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Progress Plan &rsaquo; Forfatterskolen")
 
 @section('styles')
 <style>

--- a/resources/views/frontend/learner/self-publishing/project/contract.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/contract.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/graphic-work.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/graphic-work.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/index.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/invoice.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/invoice.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/marketing-plan.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/marketing-plan.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/marketing.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/marketing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/registration.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/registration.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/service-order.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/service-order.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Service Order &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Service Order &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container" id="app-container">

--- a/resources/views/frontend/learner/self-publishing/project/show.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/show.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/self-publishing/project/storage-details.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/storage-details.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project Storage &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project Storage &rsaquo; Forfatterskolen")
 
 @section('styles')
 <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/dataTables.bootstrap4.min.css" />

--- a/resources/views/frontend/learner/self-publishing/project/storage.blade.php
+++ b/resources/views/frontend/learner/self-publishing/project/storage.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project Storage &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project Storage &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/publishing-order.blade.php
+++ b/resources/views/frontend/learner/self-publishing/publishing-order.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Publishing Order &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Publishing Order &rsaquo; Forfatterskolen")
 
 
 @section('content')

--- a/resources/views/frontend/learner/self-publishing/sales.blade.php
+++ b/resources/views/frontend/learner/self-publishing/sales.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Sales &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Sales &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-confirm/3.3.0/jquery-confirm.min.css">

--- a/resources/views/frontend/learner/self-publishing/self-publishing-list.blade.php
+++ b/resources/views/frontend/learner/self-publishing/self-publishing-list.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Project &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Project &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="learner-container">

--- a/resources/views/frontend/learner/self-publishing/time-register.blade.php
+++ b/resources/views/frontend/learner/self-publishing/time-register.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.learner.self-publishing.layout')
 
-@section('title')
-    <title>Time Register &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Time Register &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-confirm/3.3.0/jquery-confirm.min.css">

--- a/resources/views/frontend/learner/shop-manuscript-with-editing.blade.php
+++ b/resources/views/frontend/learner/shop-manuscript-with-editing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Shop Manuscripts &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Shop Manuscripts &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.manuscript.title') }} @stop
 

--- a/resources/views/frontend/learner/shop-manuscript.blade.php
+++ b/resources/views/frontend/learner/shop-manuscript.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Shop Manuscripts &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Shop Manuscripts &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.manuscript.title') }} @stop
 

--- a/resources/views/frontend/learner/shop-manuscript12042023.blade.php
+++ b/resources/views/frontend/learner/shop-manuscript12042023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Shop Manuscripts &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Shop Manuscripts &rsaquo; Forfatterskolen")
 
 @section('heading') {{ trans('site.learner.manuscript.title') }} @stop
 

--- a/resources/views/frontend/learner/shopManuscriptShow.blade.php
+++ b/resources/views/frontend/learner/shopManuscriptShow.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>{{ $shopManuscriptTaken->shop_manuscript->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $shopManuscriptTaken->shop_manuscript->title  . " &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/shopManuscriptShow12062023.blade.php
+++ b/resources/views/frontend/learner/shopManuscriptShow12062023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>{{ $shopManuscriptTaken->shop_manuscript->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $shopManuscriptTaken->shop_manuscript->title  . " &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/survey.blade.php
+++ b/resources/views/frontend/learner/survey.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $survey->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $survey->title  . " &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/terms.blade.php
+++ b/resources/views/frontend/learner/terms.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Terms &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Terms &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/learner/upgrade-assignment-orig.blade.php
+++ b/resources/views/frontend/learner/upgrade-assignment-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.front.buy') }} {{$assignment->title}}

--- a/resources/views/frontend/learner/upgrade-assignment.blade.php
+++ b/resources/views/frontend/learner/upgrade-assignment.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.front.buy') }} {{$assignment->title}}

--- a/resources/views/frontend/learner/upgrade-course-orig.blade.php
+++ b/resources/views/frontend/learner/upgrade-course-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.learner.upgrades-text') }} {{$courseTaken->package->course->title}}

--- a/resources/views/frontend/learner/upgrade-course.blade.php
+++ b/resources/views/frontend/learner/upgrade-course.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.learner.upgrades-text') }} {{$courseTaken->package->course->title}}

--- a/resources/views/frontend/learner/upgrade-manuscript-orig.blade.php
+++ b/resources/views/frontend/learner/upgrade-manuscript-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.learner.upgrades-text') }} {{$shopManuscriptTaken->shop_manuscript->title}}

--- a/resources/views/frontend/learner/upgrade-manuscript.blade.php
+++ b/resources/views/frontend/learner/upgrade-manuscript.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     {{ trans('site.learner.upgrades-text') }} {{$shopManuscriptTaken->manuscript_title}}

--- a/resources/views/frontend/learner/upgrade.blade.php
+++ b/resources/views/frontend/learner/upgrade.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('styles')
     <link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/resources/views/frontend/learner/upgrade11102023.blade.php
+++ b/resources/views/frontend/learner/upgrade11102023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Upgrade &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upgrade &rsaquo; Forfatterskolen")
 
 @section('heading')
     Oppgraderinger

--- a/resources/views/frontend/learner/webinar.blade.php
+++ b/resources/views/frontend/learner/webinar.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Mine Webinar &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Webinar &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/webinar12062023.blade.php
+++ b/resources/views/frontend/learner/webinar12062023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-    <title>Mine Webinar &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Mine Webinar &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/learner/word-written-goals.blade.php
+++ b/resources/views/frontend/learner/word-written-goals.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Word Written Goals &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Word Written Goals &rsaquo; Forfatterskolen")
 
 @section('heading')
     Word Written Goals

--- a/resources/views/frontend/learner/word-written.blade.php
+++ b/resources/views/frontend/learner/word-written.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Words Written &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Words Written &rsaquo; Forfatterskolen")
 
 @section('heading')
     Words Written

--- a/resources/views/frontend/learner/workshop.blade.php
+++ b/resources/views/frontend/learner/workshop.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Workshops &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Workshops &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container learner-workshop-wrapper">

--- a/resources/views/frontend/learner/workshop12062023.blade.php
+++ b/resources/views/frontend/learner/workshop12062023.blade.php
@@ -1,9 +1,7 @@
 {{-- @extends('frontend.layout') --}}
 @extends('frontend.layouts.course-portal')
 
-@section('title')
-<title>Workshops &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Workshops &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="learner-container learner-workshop-page">

--- a/resources/views/frontend/learner/writing-group.blade.php
+++ b/resources/views/frontend/learner/writing-group.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Writing Group &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Writing Group &rsaquo; Forfatterskolen")
 
 @section('heading') Skrivegrupper @stop
 

--- a/resources/views/frontend/learner/writing-groups.blade.php
+++ b/resources/views/frontend/learner/writing-groups.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Writing Groups &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Writing Groups &rsaquo; Forfatterskolen")
 
 @section('heading') Skrivegrupper @stop
 

--- a/resources/views/frontend/opt-in-rektor.blade.php
+++ b/resources/views/frontend/opt-in-rektor.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Forfatterskolen &rsaquo; Rektor Tips</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Rektor Tips")
 
 @section('content')
 	<div class="container">

--- a/resources/views/frontend/opt-in-terms.blade.php
+++ b/resources/views/frontend/opt-in-terms.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('content')
 	<div class="container terms-page">

--- a/resources/views/frontend/opt-in-thanks/children.blade.php
+++ b/resources/views/frontend/opt-in-thanks/children.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks" style="background-color: #f9f9f9">

--- a/resources/views/frontend/opt-in-thanks/crime.blade.php
+++ b/resources/views/frontend/opt-in-thanks/crime.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks" style="background-color: #f9f9f9">

--- a/resources/views/frontend/opt-in-thanks/dikt.blade.php
+++ b/resources/views/frontend/opt-in-thanks/dikt.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks">

--- a/resources/views/frontend/opt-in-thanks/fiction.blade.php
+++ b/resources/views/frontend/opt-in-thanks/fiction.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks" style="background-color: #f9f9f9">

--- a/resources/views/frontend/opt-in-thanks/pdf.blade.php
+++ b/resources/views/frontend/opt-in-thanks/pdf.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks">

--- a/resources/views/frontend/opt-in-thanks/referral.blade.php
+++ b/resources/views/frontend/opt-in-thanks/referral.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Blog</title>
-@stop
+@section('title', "Forfatterskolen Blog")
 
 @section('content')
     <div class="opt-in-referral" style="background-image: url({{ asset('images-new/opt-in-thanks/'.$data['image']) }})">

--- a/resources/views/frontend/opt-in-thanks/skrive.blade.php
+++ b/resources/views/frontend/opt-in-thanks/skrive.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Opt-in</title>
-@stop
+@section('title', "Forfatterskolen Opt-in")
 
 @section('content')
     <div class="opt-in-thanks">

--- a/resources/views/frontend/opt-in.blade.php
+++ b/resources/views/frontend/opt-in.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('content')
     <div id="opt-in-page">

--- a/resources/views/frontend/opt-in.blade.php.orig
+++ b/resources/views/frontend/opt-in.blade.php.orig
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('content')
 	<div class="container">

--- a/resources/views/frontend/other-service-checkout-orig.blade.php
+++ b/resources/views/frontend/other-service-checkout-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="container">

--- a/resources/views/frontend/other-service-checkout.blade.php
+++ b/resources/views/frontend/other-service-checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/other-services.blade.php
+++ b/resources/views/frontend/other-services.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen</title>
-@stop
+@section('title', "Forfatterskolen")
 
 @section('content')
     <div class="row other-services-container">

--- a/resources/views/frontend/personal-trainer/checkout.blade.php
+++ b/resources/views/frontend/personal-trainer/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/personal-trainer/thank-you.blade.php
+++ b/resources/views/frontend/personal-trainer/thank-you.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="thank-you-page">

--- a/resources/views/frontend/poems.blade.php
+++ b/resources/views/frontend/poems.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen &rsaquo; Poems</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Poems")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css">

--- a/resources/views/frontend/publishing-library.blade.php
+++ b/resources/views/frontend/publishing-library.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 
 @section('content')

--- a/resources/views/frontend/publishing-library100523.blade.php
+++ b/resources/views/frontend/publishing-library100523.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css">

--- a/resources/views/frontend/publishing-orig.blade.php
+++ b/resources/views/frontend/publishing-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 @section('content')
 

--- a/resources/views/frontend/publishing.blade.php
+++ b/resources/views/frontend/publishing.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 @section('styles')
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/malihu-custom-scrollbar-plugin/3.1.5/jquery.mCustomScrollbar.min.css">

--- a/resources/views/frontend/publishing11082018.blade.php
+++ b/resources/views/frontend/publishing11082018.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Forfatterskolen Publishing</title>
-@stop
+@section('title', "Forfatterskolen Publishing")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/publising-service/checkout.blade.php
+++ b/resources/views/frontend/publising-service/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout-self-publishing')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/publising-service/service-calculator.blade.php
+++ b/resources/views/frontend/publising-service/service-calculator.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Service Calculator</title>
-@stop
+@section('title', "Service Calculator")
 
 @section('styles')
 <link rel="stylesheet" href="{{asset('css/self-publishing.css?v='.time())}}">

--- a/resources/views/frontend/publising-service/thankyou.blade.php
+++ b/resources/views/frontend/publising-service/thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 {{-- data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png" --}}

--- a/resources/views/frontend/replay.blade.php
+++ b/resources/views/frontend/replay.blade.php
@@ -1,16 +1,9 @@
 @extends('frontend.layout')
 
-@section('title')
-    <?php
+@php
     $pageMeta = \App\PageMeta::where('url', url()->current())->first();
-    ?>
-
-    @if ($pageMeta)
-        <title>{{ $pageMeta->meta_title }}</title>
-    @else
-        <title>Reprise: Slik skriver du et førsteutkast</title>
-    @endif
-@stop
+@endphp
+@section('title', $pageMeta->meta_title ?? 'Reprise: Slik skriver du et førsteutkast')
 
 @section('styles')
     <style>

--- a/resources/views/frontend/shop-manuscript/cancelled-order.blade.php
+++ b/resources/views/frontend/shop-manuscript/cancelled-order.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Cancelled Order &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cancelled Order &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="thank-you-page" data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png">

--- a/resources/views/frontend/shop-manuscript/checkout-orig.blade.php
+++ b/resources/views/frontend/shop-manuscript/checkout-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 </div>

--- a/resources/views/frontend/shop-manuscript/checkout-svea.blade.php
+++ b/resources/views/frontend/shop-manuscript/checkout-svea.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop-manuscript/checkout-svea11212023.blade.php
+++ b/resources/views/frontend/shop-manuscript/checkout-svea11212023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop-manuscript/checkout.blade.php
+++ b/resources/views/frontend/shop-manuscript/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<link href="https://gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css" rel="stylesheet">

--- a/resources/views/frontend/shop-manuscript/free-manuscript-orig.blade.php
+++ b/resources/views/frontend/shop-manuscript/free-manuscript-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('content')
 <div class="container">

--- a/resources/views/frontend/shop-manuscript/free-manuscript-success.blade.php
+++ b/resources/views/frontend/shop-manuscript/free-manuscript-success.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('content')
 <div class="container text-center">

--- a/resources/views/frontend/shop-manuscript/free-manuscript.blade.php
+++ b/resources/views/frontend/shop-manuscript/free-manuscript.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/shop-manuscript/free-manuscript12282023.blade.php
+++ b/resources/views/frontend/shop-manuscript/free-manuscript12282023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Forfatterskolen &rsaquo; Free Manuscripts</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Free Manuscripts")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/shop-manuscript/index-orig.blade.php
+++ b/resources/views/frontend/shop-manuscript/index-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Shop Manuscripts &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Shop Manuscripts &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop-manuscript/index.blade.php
+++ b/resources/views/frontend/shop-manuscript/index.blade.php
@@ -1,16 +1,9 @@
 @extends('frontend.layout')
 
-@section('title')
-    <?php
-        $pageMeta = \App\PageMeta::where('url', url()->current())->first();
-    ?>
-
-    @if ($pageMeta)
-        <title>{{ $pageMeta->meta_title }}</title>
-    @else
-        <title>Shop Manuscripts &rsaquo; Forfatterskolen</title>
-    @endif
-@stop
+@php
+    $pageMeta = \App\PageMeta::where('url', url()->current())->first();
+@endphp
+@section('title', $pageMeta->meta_title ?? 'Shop Manuscripts &rsaquo; Forfatterskolen')
 
 @section('content')
 

--- a/resources/views/frontend/shop-manuscript/login.blade.php
+++ b/resources/views/frontend/shop-manuscript/login.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Login &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Login &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="global-checkout-page" id="app-container">

--- a/resources/views/frontend/shop-manuscript/thankyou.blade.php
+++ b/resources/views/frontend/shop-manuscript/thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 {{-- data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png" --}}

--- a/resources/views/frontend/shop-manuscript/upgrade.blade.php
+++ b/resources/views/frontend/shop-manuscript/upgrade.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/applied-discount-orig.blade.php
+++ b/resources/views/frontend/shop/applied-discount-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/shop/applied-discount.blade.php
+++ b/resources/views/frontend/shop/applied-discount.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/cancelled-order.blade.php
+++ b/resources/views/frontend/shop/cancelled-order.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Cancelled Order &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cancelled Order &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="thank-you-page" data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png">

--- a/resources/views/frontend/shop/cart.blade.php
+++ b/resources/views/frontend/shop/cart.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Cart &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Cart &rsaquo; Forfatterskolen")
 
 @section('content')
 </div>

--- a/resources/views/frontend/shop/checkout-orig.blade.php
+++ b/resources/views/frontend/shop/checkout-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/shop/checkout-share.blade.php
+++ b/resources/views/frontend/shop/checkout-share.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="checkout-page">

--- a/resources/views/frontend/shop/checkout-test.blade.php
+++ b/resources/views/frontend/shop/checkout-test.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/checkout-update.blade.php
+++ b/resources/views/frontend/shop/checkout-update.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/checkout.blade.php
+++ b/resources/views/frontend/shop/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/claim-reward.blade.php
+++ b/resources/views/frontend/shop/claim-reward.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Claim Reward &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Claim Reward &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/pay_later_thankyou.blade.php
+++ b/resources/views/frontend/shop/pay_later_thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 {{-- data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png" --}}

--- a/resources/views/frontend/shop/svea-checkout.blade.php
+++ b/resources/views/frontend/shop/svea-checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/shop/thankyou.blade.php
+++ b/resources/views/frontend/shop/thankyou.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 {{-- data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png" --}}

--- a/resources/views/frontend/skrivdittliv.blade.php
+++ b/resources/views/frontend/skrivdittliv.blade.php
@@ -1,16 +1,9 @@
 @extends('frontend.layout')
 
-@section('title')
-    <?php
+@php
     $pageMeta = \App\PageMeta::where('url', url()->current())->first();
-    ?>
-
-    @if ($pageMeta)
-        <title>{{ $pageMeta->meta_title }}</title>
-    @else
-        <title>Reprise: Slik forløser du ditt kreative potensial</title>
-    @endif
-@stop
+@endphp
+@section('title', $pageMeta->meta_title ?? 'Reprise: Slik forløser du ditt kreative potensial')
 
 @section('content')
 

--- a/resources/views/frontend/skrive2020.blade.php
+++ b/resources/views/frontend/skrive2020.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Skrive 2020</title>
-@stop
+@section('title', "Skrive 2020")
 
 @section('content')
 

--- a/resources/views/frontend/solution-article.blade.php
+++ b/resources/views/frontend/solution-article.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $article->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $article->title  . " &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="container">

--- a/resources/views/frontend/solution-articles.blade.php
+++ b/resources/views/frontend/solution-articles.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>{{ $solution->title }} Articles &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $solution->title  . " Articles &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="container">

--- a/resources/views/frontend/solution.blade.php
+++ b/resources/views/frontend/solution.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Support &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Support &rsaquo; Forfatterskolen")
 
 @section('content')
     <div class="container">

--- a/resources/views/frontend/subscribe-success.blade.php
+++ b/resources/views/frontend/subscribe-success.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You for Subscribing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You for Subscribing &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="container">

--- a/resources/views/frontend/subscribe-success11162023.blade.php
+++ b/resources/views/frontend/subscribe-success11162023.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You for Subscribing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You for Subscribing &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="container">

--- a/resources/views/frontend/terms.blade.php
+++ b/resources/views/frontend/terms.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-	<title>Forfatterskolen &rsaquo; Terms</title>
-@stop
+@section('title', "Forfatterskolen &rsaquo; Terms")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/thank-you.blade.php
+++ b/resources/views/frontend/thank-you.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Thank You &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You &rsaquo; Forfatterskolen")
 
 @section('content')
 {{-- data-bg="https://www.forfatterskolen.no/images-new/thankyou-bg.png" --}}

--- a/resources/views/frontend/upviral-campaign/test.blade.php
+++ b/resources/views/frontend/upviral-campaign/test.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Upviral &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upviral &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/upviral-campaign/webinar-pakke.blade.php
+++ b/resources/views/frontend/upviral-campaign/webinar-pakke.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Upviral &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Upviral &rsaquo; Forfatterskolen")
 
 @section('styles')
     <style>

--- a/resources/views/frontend/webinar-thanks.blade.php
+++ b/resources/views/frontend/webinar-thanks.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Thank You for Subscribing &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Thank You for Subscribing &rsaquo; Forfatterskolen")
 
 @section('styles')
 	<style>

--- a/resources/views/frontend/workshop/checkout-orig.blade.php
+++ b/resources/views/frontend/workshop/checkout-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 </div>

--- a/resources/views/frontend/workshop/checkout.blade.php
+++ b/resources/views/frontend/workshop/checkout.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Checkout &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Checkout &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="checkout-page">

--- a/resources/views/frontend/workshop/index-orig.blade.php
+++ b/resources/views/frontend/workshop/index-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>Workshops &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Workshops &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/workshop/index.blade.php
+++ b/resources/views/frontend/workshop/index.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-    <title>Workshops &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', "Workshops &rsaquo; Forfatterskolen")
 
 @section('content')
 

--- a/resources/views/frontend/workshop/show-orig.blade.php
+++ b/resources/views/frontend/workshop/show-orig.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>{{ $workshop->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $workshop->title  . " &rsaquo; Forfatterskolen")
 
 @section('content')
 <div class="container course-details-container">

--- a/resources/views/frontend/workshop/show.blade.php
+++ b/resources/views/frontend/workshop/show.blade.php
@@ -1,8 +1,6 @@
 @extends('frontend.layout')
 
-@section('title')
-<title>{{ $workshop->title }} &rsaquo; Forfatterskolen</title>
-@stop
+@section('title', $workshop->title  . " &rsaquo; Forfatterskolen")
 
 @section('content')
 	<div class="workshop-single-page">


### PR DESCRIPTION
## Summary
- centralize page titles by yielding `@section('title')` in frontend layouts
- replace view `<title>` tags with `@section('title', ...)`

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ada95537bc832d805eca930e1073b5