### PR TITLE
Update fiken contact handling on learner update

### DIFF
--- a/app/Console/Commands/CheckFikenContactCommand.php
+++ b/app/Console/Commands/CheckFikenContactCommand.php
@@ -37,38 +37,45 @@ class CheckFikenContactCommand extends Command
     public function handle(): void
     {
         $users = User::whereNull('fiken_contact_id')->get();
-        $company = 'forfatterskolen-as';
 
         foreach ($users as $user) {
-            $fikenUrl = 'https://api.fiken.no/api/v2/companies/'.$company.'/contacts?email='.$user->email;
-            $headers = [
-                'Accept: application/json',
-                'Authorization: Bearer '.config('services.fiken.personal_api_key'),
-                'Content-Type: Application/json',
-            ];
-
-            $ch = curl_init($fikenUrl);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-            curl_setopt($ch, CURLOPT_HEADER, 1);
-
-            $response = curl_exec($ch);
-            $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-            $body = substr($response, $header_size);
-            $fikenContacts = json_decode($body);
-
-            if ($fikenContacts) {
-                $user->fill([
-                    'fiken_contact_id' => $fikenContacts[0]->contactId,
-                ])->save();
-            } else {
-                $user->fill([
-                    'fiken_contact_id' => 'none',
-                ])->save();
-            }
-
+            self::updateFikenContactId($user);
         }
 
         echo 'Done';
+    }
+
+    /**
+     * Retrieve and update the fiken contact id for the given user.
+     */
+    public static function updateFikenContactId(User $user): void
+    {
+        $company = 'forfatterskolen-as';
+        $fikenUrl = 'https://api.fiken.no/api/v2/companies/'.$company.'/contacts?email='.$user->email;
+        $headers = [
+            'Accept: application/json',
+            'Authorization: Bearer '.config('services.fiken.personal_api_key'),
+            'Content-Type: Application/json',
+        ];
+
+        $ch = curl_init($fikenUrl);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+
+        $response = curl_exec($ch);
+        $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+        $body = substr($response, $header_size);
+        $fikenContacts = json_decode($body);
+
+        if ($fikenContacts) {
+            $user->fill([
+                'fiken_contact_id' => $fikenContacts[0]->contactId,
+            ])->save();
+        } else {
+            $user->fill([
+                'fiken_contact_id' => 'none',
+            ])->save();
+        }
     }
 }

--- a/app/Http/Controllers/Backend/LearnerController.php
+++ b/app/Http/Controllers/Backend/LearnerController.php
@@ -57,6 +57,7 @@ use App\Workshop;
 use App\WorkshopMenu;
 use App\WorkshopsTaken;
 use App\WorkshopTakenCount;
+use App\Console\Commands\CheckFikenContactCommand;
 use Carbon\Carbon;
 use DB;
 use File;
@@ -286,6 +287,10 @@ class LearnerController extends Controller
                 $address->zip = $request->zip;
                 $address->city = $request->city;
                 $address->save();
+
+                if (! $learner->fiken_contact_id || $learner->fiken_contact_id == 'none') {
+                    CheckFikenContactCommand::updateFikenContactId($learner);
+                }
 
                 if ($learner->fiken_contact_id && $learner->fiken_contact_id != 'none') {
                     dispatch(new UpdateFikenContactDetailsJob($learner));


### PR DESCRIPTION
## Summary
- expose reusable method to update user Fiken contact ID
- ensure backend learner contact updates fetch missing Fiken ID then sync details

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b63d4d31e48325b047f360af4123c2