### PR TITLE
feat: add coaching time booking workflow

### DIFF
--- a/app/CoachingTimeRequest.php
+++ b/app/CoachingTimeRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CoachingTimeRequest extends Model
+{
+    protected $fillable = ['coaching_timer_manuscript_id', 'editor_time_slot_id', 'status'];
+
+    public function manuscript(): BelongsTo
+    {
+        return $this->belongsTo(CoachingTimerManuscript::class, 'coaching_timer_manuscript_id');
+    }
+
+    public function slot(): BelongsTo
+    {
+        return $this->belongsTo(EditorTimeSlot::class, 'editor_time_slot_id');
+    }
+}

--- a/app/CoachingTimerManuscript.php
+++ b/app/CoachingTimerManuscript.php
@@ -2,8 +2,12 @@
 
 namespace App;
 
+use App\User;
+use App\EditorTimeSlot;
+use App\CoachingTimeRequest;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class CoachingTimerManuscript extends Model
 {
@@ -16,28 +20,28 @@ class CoachingTimerManuscript extends Model
 
     const STATUS_BOOKED = 2;
 
-    /**
-     * The database table used by the model.
-     *
-     * @var string
-     */
     protected $table = 'coaching_timer_manuscripts';
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
     protected $fillable = ['user_id', 'file', 'payment_price', 'plan_type', 'help_with', 'suggested_date', 'approved_date',
-        'suggested_date_admin', 'editor_id', 'replay_link', 'comment', 'document', 'status', 'is_approved', 'hours_worked'];
+        'suggested_date_admin', 'editor_id', 'editor_time_slot_id', 'replay_link', 'comment', 'document', 'status', 'is_approved', 'hours_worked'];
 
     public function user(): BelongsTo
     {
-        return $this->belongsTo(\App\User::class);
+        return $this->belongsTo(User::class);
     }
 
     public function editor(): BelongsTo
     {
-        return $this->belongsTo(\App\User::class, 'editor_id', 'id');
+        return $this->belongsTo(User::class, 'editor_id', 'id');
+    }
+
+    public function timeSlot(): BelongsTo
+    {
+        return $this->belongsTo(EditorTimeSlot::class, 'editor_time_slot_id');
+    }
+
+    public function requests(): HasMany
+    {
+        return $this->hasMany(CoachingTimeRequest::class, 'coaching_timer_manuscript_id');
     }
 }

--- a/app/EditorTimeSlot.php
+++ b/app/EditorTimeSlot.php
@@ -2,14 +2,23 @@
 
 namespace App;
 
+use App\User;
+use App\CoachingTimeRequest;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class EditorTimeSlot extends Model
 {
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
     protected $fillable = ['editor_id', 'date', 'start_time', 'duration'];
+
+    public function editor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'editor_id');
+    }
+
+    public function requests(): HasMany
+    {
+        return $this->hasMany(CoachingTimeRequest::class, 'editor_time_slot_id');
+    }
 }

--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -2,17 +2,25 @@
 
 namespace App\Http\Controllers\Editor;
 
+use App\CoachingTimeRequest;
 use App\EditorTimeSlot;
 use App\Http\Controllers\Controller;
 use Auth;
 use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
-class CoachingTimeController extends Controller {
-
+class CoachingTimeController extends Controller
+{
     public function index()
     {
-        return view('editor.coaching-time.index');
+        $requests = CoachingTimeRequest::whereHas('slot', function ($q) {
+            $q->where('editor_id', Auth::id());
+        })->where('status', 'pending')
+            ->with(['manuscript.user', 'slot'])
+            ->get();
+
+        return view('editor.coaching-time.index', compact('requests'));
     }
 
     public function calendar()
@@ -25,14 +33,12 @@ class CoachingTimeController extends Controller {
         $slots = EditorTimeSlot::where('editor_id', Auth::user()->id)->get();
 
         $events = $slots->map(function ($slot) {
-            // 👇 Tell Carbon these DB fields are UTC
             $startUtc = Carbon::parse("{$slot->date} {$slot->start_time}", 'UTC');
             $endUtc   = (clone $startUtc)->addMinutes($slot->duration);
 
             return [
                 'id'    => $slot->id,
                 'title' => $slot->duration . ' min',
-                // 👇 Send Zulu time so the client knows it's UTC
                 'start' => $startUtc->toIso8601ZuluString(),
                 'end'   => $endUtc->toIso8601ZuluString(),
             ];
@@ -67,4 +73,22 @@ class CoachingTimeController extends Controller {
         return response()->json(['success' => true]);
     }
 
+    public function acceptRequest($id): RedirectResponse
+    {
+        $request = CoachingTimeRequest::with(['slot', 'manuscript'])->findOrFail($id);
+
+        if ($request->slot->editor_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $request->status = 'accepted';
+        $request->save();
+
+        $manuscript = $request->manuscript;
+        $manuscript->editor_id = Auth::id();
+        $manuscript->editor_time_slot_id = $request->editor_time_slot_id;
+        $manuscript->save();
+
+        return redirect()->back()->with('success', 'Request accepted.');
+    }
 }

--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -11,6 +11,8 @@ use App\AssignmentGroup;
 use App\AssignmentGroupLearner;
 use App\AssignmentManuscript;
 use App\CalendarNote;
+use App\EditorTimeSlot;
+use App\CoachingTimeRequest;
 use App\CoachingTimerManuscript;
 use App\CoachingTimerTaken;
 use App\Contract;
@@ -5694,6 +5696,39 @@ class LearnerController extends Controller
         return response()->json([
             'message' => $decode ? $decode->message : '',
         ], $httpcode);
+    }
+
+    public function coachingTime()
+    {
+        $coachingTimer = CoachingTimerManuscript::where("user_id", Auth::id())
+            ->whereNull("editor_id")
+            ->first();
+
+        $editors = EditorTimeSlot::with("editor")
+            ->whereDoesntHave("requests", function($q){
+                $q->where("status", "accepted");
+            })
+            ->orderBy("date")
+            ->get()
+            ->groupBy("editor_id");
+
+        return view("frontend.learners.coaching-time", compact("editors", "coachingTimer"));
+    }
+
+    public function requestCoachingTime(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            "coaching_timer_id" => "required|exists:coaching_timer_manuscripts,id",
+            "editor_time_slot_id" => "required|exists:editor_time_slots,id",
+        ]);
+
+        CoachingTimeRequest::create([
+            "coaching_timer_manuscript_id" => $data["coaching_timer_id"],
+            "editor_time_slot_id" => $data["editor_time_slot_id"],
+            "status" => "pending",
+        ]);
+
+        return redirect()->route("learner.coaching-time")->with("success", "Time slot requested.");
     }
 
     public function currentUser()

--- a/database/migrations/2025_09_02_000000_create_coaching_time_requests_table.php
+++ b/database/migrations/2025_09_02_000000_create_coaching_time_requests_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCoachingTimeRequestsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('coaching_time_requests', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('coaching_timer_manuscript_id');
+            $table->unsignedBigInteger('editor_time_slot_id');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+
+            $table->foreign('coaching_timer_manuscript_id')
+                ->references('id')->on('coaching_timer_manuscripts')
+                ->onDelete('cascade');
+            $table->foreign('editor_time_slot_id')
+                ->references('id')->on('editor_time_slots')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('coaching_time_requests');
+    }
+}

--- a/database/migrations/2025_09_02_000001_add_editor_time_slot_id_to_coaching_timer_manuscripts_table.php
+++ b/database/migrations/2025_09_02_000001_add_editor_time_slot_id_to_coaching_timer_manuscripts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEditorTimeSlotIdToCoachingTimerManuscriptsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('coaching_timer_manuscripts', function (Blueprint $table) {
+            $table->unsignedBigInteger('editor_time_slot_id')->nullable()->after('editor_id');
+            $table->foreign('editor_time_slot_id')
+                ->references('id')->on('editor_time_slots')
+                ->onDelete('set null');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('coaching_timer_manuscripts', function (Blueprint $table) {
+            $table->dropForeign(['editor_time_slot_id']);
+            $table->dropColumn('editor_time_slot_id');
+        });
+    }
+}

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -83,8 +83,7 @@
                     </div>
                     <div class="panel-body">
                         <p>Klikk på kalenderen for manuelt gjennomgang av redaksjonstimer</p>
-                        <a href="{{ route('editor.coaching-time.calendar') }}" class="btn btn-default btn-block" 
-                        style="margin-bottom:15px;">
+                        <a href="{{ route('editor.coaching-time.calendar') }}" class="btn btn-default btn-block" style="margin-bottom:15px;">
                             Åpne Redaktørkalender
                         </a>
                         <a href="#" class="btn btn-default btn-block">Gjenåpne Redaksjonstimer</a>
@@ -133,6 +132,43 @@
                                     <td>Utfordring</td>
                                     <td><a href="#" class="btn btn-default btn-xs">Beskrivelse</a></td>
                                 </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4>Forespørsler fra studenter</h4>
+                    </div>
+                    <div class="panel-body">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Student</th>
+                                    <th>Tid</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @forelse($requests as $req)
+                                    <tr>
+                                        <td>{{ $req->manuscript->user->name }}</td>
+                                        <td>{{ \Carbon\Carbon::parse($req->slot->date)->format('d.m.Y') }} {{ $req->slot->start_time }}</td>
+                                        <td>
+                                            <form method="POST" action="{{ route('editor.coaching-time.request.accept', $req->id) }}">
+                                                @csrf
+                                                <button class="btn btn-primary btn-xs">Accept</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr><td colspan="3">Ingen forespørsler.</td></tr>
+                                @endforelse
                             </tbody>
                         </table>
                     </div>

--- a/resources/views/frontend/learners/coaching-time.blade.php
+++ b/resources/views/frontend/learners/coaching-time.blade.php
@@ -1,0 +1,43 @@
+@extends('frontend.layouts.course-portal')
+
+@section('title')
+    <title>Coaching Time &rsaquo; Forfatterskolen</title>
+@endsection
+
+@section('content')
+<div class="learner-container coaching-time-wrapper">
+    <div class="container">
+        <h1 class="page-title">Coaching Time</h1>
+        @if(session('success'))
+            <div class="alert alert-success">{{ session('success') }}</div>
+        @endif
+        @isset($coachingTimer)
+            <h3>Tilgjengelige Bokredaktører</h3>
+            @forelse($editors as $editorSlots)
+                <div class="panel panel-default">
+                    <div class="panel-heading">{{ $editorSlots->first()->editor->name }}</div>
+                    <div class="panel-body">
+                        <ul class="list-unstyled">
+                            @foreach($editorSlots as $slot)
+                                <li>
+                                    {{ \Carbon\Carbon::parse($slot->date)->format('d.m.Y') }} {{ $slot->start_time }} ({{ $slot->duration }} min)
+                                    <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="pull-right">
+                                        @csrf
+                                        <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                                        <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
+                                        <button type="submit" class="btn btn-xs btn-primary">Book</button>
+                                    </form>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                </div>
+            @empty
+                <p>Ingen tilgjengelige tidsluker.</p>
+            @endforelse
+        @else
+            <p>Ingen coaching time tilgjengelig.</p>
+        @endisset
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -328,6 +328,8 @@ Route::domain($front)->group(function () {
         Route::put('/writing-group/{id}', [Frontend\LearnerController::class, 'writingGroup'])->name('learner.update.writing-group'); // Writing Group Page
         Route::get('/competition', [Frontend\LearnerController::class, 'competition'])->name('learner.competition'); // Competitions Page
         Route::get('/private-message', [Frontend\LearnerController::class, 'privateMessage'])->name('learner.private-message'); // Private Message Page
+        Route::get('/coaching-time', [Frontend\LearnerController::class, 'coachingTime'])->name('learner.coaching-time');
+        Route::post('/coaching-time/request', [Frontend\LearnerController::class, 'requestCoachingTime'])->name('learner.coaching-time.request');
         Route::get('/time-register', [Frontend\LearnerController::class, 'timeRegister'])->name('learner.time-register');
         Route::get('/book-sale', [Frontend\LearnerController::class, 'bookSale'])->name('learner.book-sale');
         Route::get('/book-for-sale/{id}', [Frontend\LearnerController::class, 'bookForSale'])->name('learner.book-for-sale');
@@ -1964,6 +1966,7 @@ Route::domain($editor)->group(function () {
                     Route::post('/',  'storeTimeSlot')->name('store');
                     Route::delete('{id}', 'destroyTimeSlot')->name('destroy');
                 });
+                Route::post('/request/{id}/accept', 'acceptRequest')->name('request.accept');
             });
         });
     });


### PR DESCRIPTION
## Summary
- add learner coaching time page for booking editor slots
- track coaching time requests and approved slots
- allow editors to accept coaching time requests

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/forfatterskolen/vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b182cafc83259725b056bc2e78e9