### PR TITLE
feat: move learner coaching slots to dedicated page

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5715,6 +5715,23 @@ class LearnerController extends Controller
         return view("frontend.learner.coaching-time", compact("editors", "coachingTimer"));
     }
 
+    public function availableCoachingTime()
+    {
+        $coachingTimer = CoachingTimerManuscript::where("user_id", Auth::id())
+            ->whereNull("editor_id")
+            ->first();
+
+        $editors = EditorTimeSlot::with("editor")
+            ->whereDoesntHave("requests", function($q){
+                $q->where("status", "accepted");
+            })
+            ->orderBy("date")
+            ->get()
+            ->groupBy("editor_id");
+
+        return view("frontend.learner.coaching-time-available", compact("editors", "coachingTimer"));
+    }
+
     public function requestCoachingTime(Request $request): RedirectResponse
     {
         $data = $request->validate([

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -1,0 +1,58 @@
+@extends('frontend.layouts.course-portal')
+
+@section('title')
+    <title>Available Time Slots &rsaquo; Forfatterskolen</title>
+@endsection
+
+@section('styles')
+<style>
+    .slot-card {
+        border: 1px solid #e4e4e7;
+        border-radius: 5px;
+        padding: 15px;
+        text-align: center;
+        margin: 5px;
+        width: 120px;
+        display: inline-block;
+    }
+</style>
+@stop
+
+@section('content')
+<div class="learner-container coaching-time-wrapper">
+    <div class="container">
+        <h1 class="page-title">Available Time Slots</h1>
+
+        @isset($coachingTimer)
+            @foreach($editors as $editorSlots)
+                <h3 class="mt-4">Available Time Slots - {{ $editorSlots->first()->editor->full_name }}</h3>
+
+                @foreach($editorSlots->groupBy('date') as $date => $slots)
+                    <div class="mb-4">
+                        <h4>{{ \Carbon\Carbon::parse($date, 'UTC')->setTimezone(config('app.timezone'))->isoFormat('dddd - MMMM D') }}</h4>
+                        <div class="d-flex flex-wrap">
+                            @foreach($slots as $slot)
+                                <div class="slot-card">
+                                    <div><i class="fa fa-clock-o"></i></div>
+                                    <div class="mt-2">{{ \Carbon\Carbon::parse($slot->date.' '.$slot->start_time, 'UTC')->setTimezone(config('app.timezone'))->format('H:i') }}</div>
+                                    <div>{{ $slot->duration }} min</div>
+                                    <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
+                                        @csrf
+                                        <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                                        <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
+                                        <button type="submit" class="btn btn-primary btn-sm">Book</button>
+                                    </form>
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
+            @endforeach
+        @else
+            <p>Ingen coaching time tilgjengelig.</p>
+        @endisset
+
+        <a href="{{ route('learner.coaching-time') }}" class="btn btn-secondary mt-4">Back</a>
+    </div>
+</div>
+@endsection

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -47,14 +47,6 @@
         background: #000000;
         color: #ffffff;
     }
-
-    #editorAccordion a {
-        color: #862736;
-    }
-
-    #editorAccordion a:hover {
-        text-decoration: underline;
-    }
 </style>
 @stop
 
@@ -107,9 +99,9 @@
                     <span>Velg redaktør og tid for å booke din neste sesjon.</span>
                     
                     @isset($coachingTimer)
-                        <button class="btn black-btn mt-4" data-toggle="modal" data-target="#availableTimesModal">
+                        <a href="{{ route('learner.coaching-time.available') }}" class="btn black-btn mt-4">
                             Se Tilgjengelige Tider
-                        </button>
+                        </a>
                     @else
                         <p>Ingen coaching time tilgjengelig.</p>
                     @endisset
@@ -148,56 +140,4 @@
     </div>
 </div>
 
-<!-- Modal -->
-<div id="availableTimesModal" class="modal fade" role="dialog" data-backdrop="static">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title">Tilgjengelige Tider</h4>
-
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="panel-group" id="editorAccordion" role="tablist" aria-multiselectable="true">
-                    @isset($coachingTimer)
-                        @forelse($editors as $editorId => $editorSlots)
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="heading{{ $editorId }}">
-                                    <h4 class="panel-title">
-                                        <a role="button" data-toggle="collapse" data-parent="#editorAccordion" href="#collapse{{ $editorId }}" aria-expanded="false" aria-controls="collapse{{ $editorId }}">
-                                            {{ $editorSlots->first()->editor->full_name }}
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="collapse{{ $editorId }}" class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading{{ $editorId }}">
-                                    <div class="panel-body">
-                                        <ul class="list-unstyled">
-                                            @foreach($editorSlots as $slot)
-                                                <li class="clearfix">
-                                                    {{ \Carbon\Carbon::parse($slot->date)->format('d.m.Y') }} {{ $slot->start_time }} ({{ $slot->duration }} min)
-                                                    <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="pull-right">
-                                                        @csrf
-                                                        <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
-                                                        <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
-                                                        <button type="submit" class="btn btn-xs btn-primary">Book</button>
-                                                    </form>
-                                                </li>
-                                            @endforeach
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        @empty
-                            <p>Ingen tilgjengelige tidsluker.</p>
-                        @endforelse
-                    @else
-                        <p>Ingen coaching time tilgjengelig.</p>
-                    @endisset
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -329,6 +329,7 @@ Route::domain($front)->group(function () {
         Route::get('/competition', [Frontend\LearnerController::class, 'competition'])->name('learner.competition'); // Competitions Page
         Route::get('/private-message', [Frontend\LearnerController::class, 'privateMessage'])->name('learner.private-message'); // Private Message Page
         Route::get('/coaching-time', [Frontend\LearnerController::class, 'coachingTime'])->name('learner.coaching-time');
+        Route::get('/coaching-time/available', [Frontend\LearnerController::class, 'availableCoachingTime'])->name('learner.coaching-time.available');
         Route::post('/coaching-time/request', [Frontend\LearnerController::class, 'requestCoachingTime'])->name('learner.coaching-time.request');
         Route::get('/time-register', [Frontend\LearnerController::class, 'timeRegister'])->name('learner.time-register');
         Route::get('/book-sale', [Frontend\LearnerController::class, 'bookSale'])->name('learner.book-sale');


### PR DESCRIPTION
## Summary
- route learner coaching time slots to a new `/coaching-time/available` page
- add controller method and view showing grouped slots per editor with localised times
- replace modal trigger in coaching time page with link to the new listing

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f546f6dc83258bbc5a352cfaef85