### PR TITLE
Sort coaching slots and add decline option

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -91,4 +91,18 @@ class CoachingTimeController extends Controller
 
         return redirect()->back()->with('success', 'Request accepted.');
     }
+
+    public function declineRequest($id): RedirectResponse
+    {
+        $request = CoachingTimeRequest::with('slot')->findOrFail($id);
+
+        if ($request->slot->editor_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $request->status = 'declined';
+        $request->save();
+
+        return redirect()->back()->with('success', 'Request declined.');
+    }
 }

--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5704,13 +5704,14 @@ class LearnerController extends Controller
             ->whereNull("editor_id")
             ->first();
 
-        $editors = EditorTimeSlot::with("editor")
-            ->whereDoesntHave("requests", function($q){
-                $q->where("status", "accepted");
+        $editors = EditorTimeSlot::with('editor')
+            ->whereDoesntHave('requests', function ($q) {
+                $q->where('status', 'accepted');
             })
-            ->orderBy("date")
+            ->orderBy('date')
+            ->orderBy('start_time')
             ->get()
-            ->groupBy("editor_id");
+            ->groupBy('editor_id');
 
         return view("frontend.learner.coaching-time", compact("editors", "coachingTimer"));
     }
@@ -5721,13 +5722,14 @@ class LearnerController extends Controller
             ->whereNull("editor_id")
             ->first();
 
-        $editors = EditorTimeSlot::with("editor")
-            ->whereDoesntHave("requests", function($q){
-                $q->where("status", "accepted");
+        $editors = EditorTimeSlot::with(['editor', 'requests'])
+            ->whereDoesntHave('requests', function ($q) {
+                $q->where('status', 'accepted');
             })
-            ->orderBy("date")
+            ->orderBy('date')
+            ->orderBy('start_time')
             ->get()
-            ->groupBy("editor_id");
+            ->groupBy('editor_id');
 
         return view("frontend.learner.coaching-time-available", compact("editors", "coachingTimer"));
     }
@@ -5735,17 +5737,25 @@ class LearnerController extends Controller
     public function requestCoachingTime(Request $request): RedirectResponse
     {
         $data = $request->validate([
-            "coaching_timer_id" => "required|exists:coaching_timer_manuscripts,id",
-            "editor_time_slot_id" => "required|exists:editor_time_slots,id",
+            'coaching_timer_id'   => 'required|exists:coaching_timer_manuscripts,id',
+            'editor_time_slot_id' => 'required|exists:editor_time_slots,id',
         ]);
+
+        $exists = CoachingTimeRequest::where('coaching_timer_manuscript_id', $data['coaching_timer_id'])
+            ->where('editor_time_slot_id', $data['editor_time_slot_id'])
+            ->exists();
+
+        if ($exists) {
+            return redirect()->back()->with('error', 'You have already requested this time slot.');
+        }
 
         CoachingTimeRequest::create([
-            "coaching_timer_manuscript_id" => $data["coaching_timer_id"],
-            "editor_time_slot_id" => $data["editor_time_slot_id"],
-            "status" => "pending",
+            'coaching_timer_manuscript_id' => $data['coaching_timer_id'],
+            'editor_time_slot_id'          => $data['editor_time_slot_id'],
+            'status'                       => 'pending',
         ]);
 
-        return redirect()->route("learner.coaching-time")->with("success", "Time slot requested.");
+        return redirect()->route('learner.coaching-time')->with('success', 'Time slot requested.');
     }
 
     public function currentUser()

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -160,9 +160,13 @@
                                         <td>{{ $req->manuscript->user->name }}</td>
                                         <td>{{ \Carbon\Carbon::parse($req->slot->date)->format('d.m.Y') }} {{ $req->slot->start_time }}</td>
                                         <td>
-                                            <form method="POST" action="{{ route('editor.coaching-time.request.accept', $req->id) }}">
+                                            <form method="POST" action="{{ route('editor.coaching-time.request.accept', $req->id) }}" class="d-inline">
                                                 @csrf
                                                 <button class="btn btn-primary btn-xs">Accept</button>
+                                            </form>
+                                            <form method="POST" action="{{ route('editor.coaching-time.request.decline', $req->id) }}" class="d-inline">
+                                                @csrf
+                                                <button class="btn btn-danger btn-xs">Decline</button>
                                             </form>
                                         </td>
                                     </tr>

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -34,7 +34,7 @@
                         <h3 class="mt-4">Available Time Slots - {{ $editorSlots->first()->editor->full_name }}</h3>
 
                         @php
-                            $dateGroups = $editorSlots->groupBy('date');
+                            $dateGroups = $editorSlots->groupBy('date')->sortKeys();
                             $chunks = $dateGroups->chunk(7);
                         @endphp
 
@@ -56,17 +56,24 @@
                                         <div class="mb-4">
                                             <h4>{{ \Carbon\Carbon::parse($date, 'UTC')->isoFormat('dddd - MMMM D') }}</h4>
                                             <div class="d-flex flex-wrap">
-                                                @foreach($slots as $slot)
+                                                @foreach($slots->sortBy('start_time') as $slot)
                                                     <div class="slot-card">
                                                         <div><i class="fa fa-clock-o"></i></div>
                                                         <div class="mt-2 slot-time" data-time="{{ \Carbon\Carbon::parse($slot->date.' '.$slot->start_time, 'UTC')->toIso8601String() }}"></div>
                                                         <div>{{ $slot->duration }} min</div>
-                                                        <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
-                                                            @csrf
-                                                            <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
-                                                            <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
-                                                            <button type="submit" class="btn btn-primary btn-sm">Book</button>
-                                                        </form>
+                                                        @php
+                                                            $requested = $slot->requests->where('coaching_timer_manuscript_id', $coachingTimer->id)->isNotEmpty();
+                                                        @endphp
+                                                        @if($requested)
+                                                            <div class="mt-2 text-muted">Requested</div>
+                                                        @else
+                                                            <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
+                                                                @csrf
+                                                                <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                                                                <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
+                                                                <button type="submit" class="btn btn-primary btn-sm">Book</button>
+                                                            </form>
+                                                        @endif
                                                     </div>
                                                 @endforeach
                                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1968,6 +1968,7 @@ Route::domain($editor)->group(function () {
                     Route::delete('{id}', 'destroyTimeSlot')->name('destroy');
                 });
                 Route::post('/request/{id}/accept', 'acceptRequest')->name('request.accept');
+                Route::post('/request/{id}/decline', 'declineRequest')->name('request.decline');
             });
         });
     });


### PR DESCRIPTION
## Summary
- show available coaching times in ascending order and prevent learners from booking a slot twice
- allow editors to decline coaching time requests

## Testing
- `vendor/bin/phpunit` *(fails: php-http/discovery download requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68b902ac1a80832599d771d7352ade49