### PR TITLE
Allow selecting coaching timer when multiple available

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5700,9 +5700,9 @@ class LearnerController extends Controller
 
     public function coachingTime()
     {
-        $coachingTimer = CoachingTimerManuscript::where("user_id", Auth::id())
-            ->whereNull("editor_id")
-            ->first();
+        $coachingTimers = CoachingTimerManuscript::where('user_id', Auth::id())
+            ->whereNull('editor_id')
+            ->get();
 
         $editors = EditorTimeSlot::with('editor')
             ->whereDoesntHave('requests', function ($q) {
@@ -5713,14 +5713,19 @@ class LearnerController extends Controller
             ->get()
             ->groupBy('editor_id');
 
-        return view("frontend.learner.coaching-time", compact("editors", "coachingTimer"));
+        return view('frontend.learner.coaching-time', compact('editors', 'coachingTimers'));
     }
 
-    public function availableCoachingTime()
+    public function availableCoachingTime(Request $request)
     {
-        $coachingTimer = CoachingTimerManuscript::where("user_id", Auth::id())
-            ->whereNull("editor_id")
-            ->first();
+        $timerQuery = CoachingTimerManuscript::where('user_id', Auth::id())
+            ->whereNull('editor_id');
+
+        if ($request->filled('coaching_timer_id')) {
+            $timerQuery->where('id', $request->input('coaching_timer_id'));
+        }
+
+        $coachingTimer = $timerQuery->first();
 
         $editors = EditorTimeSlot::with(['editor', 'requests'])
             ->whereDoesntHave('requests', function ($q) {
@@ -5731,7 +5736,7 @@ class LearnerController extends Controller
             ->get()
             ->groupBy('editor_id');
 
-        return view("frontend.learner.coaching-time-available", compact("editors", "coachingTimer"));
+        return view('frontend.learner.coaching-time-available', compact('editors', 'coachingTimer'));
     }
 
     public function requestCoachingTime(Request $request): RedirectResponse

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -102,13 +102,25 @@
                     <h3>Book Redaksjonstime</h3>
                     <span>Velg redaktør og tid for å booke din neste sesjon.</span>
                     
-                    @isset($coachingTimer)
-                        <a href="{{ route('learner.coaching-time.available') }}" class="btn black-btn mt-4">
+                    @if($coachingTimers->count() === 1)
+                        <a href="{{ route('learner.coaching-time.available', ['coaching_timer_id' => $coachingTimers->first()->id]) }}" class="btn black-btn mt-4">
                             Se Tilgjengelige Tider
                         </a>
+                    @elseif($coachingTimers->count() > 1)
+                        <form action="{{ route('learner.coaching-time.available') }}" method="GET" class="mt-4">
+                            <div class="form-group">
+                                <label for="coaching_timer_id">Velg Coaching Time</label>
+                                <select name="coaching_timer_id" id="coaching_timer_id" class="form-control">
+                                    @foreach($coachingTimers as $timer)
+                                        <option value="{{ $timer->id }}">Coaching Time #{{ $loop->iteration }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <button type="submit" class="btn black-btn mt-2">Se Tilgjengelige Tider</button>
+                        </form>
                     @else
                         <p>Ingen coaching time tilgjengelig.</p>
-                    @endisset
+                    @endif
                 </div>
             </div>
             <div class="col-md-6">


### PR DESCRIPTION
## Summary
- Fetch all unassigned coaching timers for a learner instead of just the first
- Allow learners to choose which coaching timer to book when multiple exist
- Support timer selection through optional parameter in available slots view

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b940066d708325a9b3b47085612fc3