### PR TITLE
Add coaching timer selection modal when booking slots

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5718,14 +5718,16 @@ class LearnerController extends Controller
 
     public function availableCoachingTime(Request $request)
     {
-        $timerQuery = CoachingTimerManuscript::where('user_id', Auth::id())
-            ->whereNull('editor_id');
+        $coachingTimers = CoachingTimerManuscript::where('user_id', Auth::id())
+            ->whereNull('editor_id')
+            ->get();
 
+        $coachingTimer = null;
         if ($request->filled('coaching_timer_id')) {
-            $timerQuery->where('id', $request->input('coaching_timer_id'));
+            $coachingTimer = $coachingTimers->where('id', $request->input('coaching_timer_id'))->first();
+        } elseif ($coachingTimers->count() === 1) {
+            $coachingTimer = $coachingTimers->first();
         }
-
-        $coachingTimer = $timerQuery->first();
 
         $editors = EditorTimeSlot::with(['editor', 'requests'])
             ->whereDoesntHave('requests', function ($q) {
@@ -5736,7 +5738,7 @@ class LearnerController extends Controller
             ->get()
             ->groupBy('editor_id');
 
-        return view('frontend.learner.coaching-time-available', compact('editors', 'coachingTimer'));
+        return view('frontend.learner.coaching-time-available', compact('editors', 'coachingTimer', 'coachingTimers'));
     }
 
     public function requestCoachingTime(Request $request): RedirectResponse

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -29,7 +29,7 @@
                 <h1 class="page-title">Available Time Slots</h1>
             
 
-                @isset($coachingTimer)
+                @if($coachingTimers->count())
                     @foreach($editors as $editorSlots)
                         <h3 class="mt-4">Available Time Slots - {{ $editorSlots->first()->editor->full_name }}</h3>
 
@@ -62,17 +62,21 @@
                                                         <div class="mt-2 slot-time" data-time="{{ \Carbon\Carbon::parse($slot->date.' '.$slot->start_time, 'UTC')->toIso8601String() }}"></div>
                                                         <div>{{ $slot->duration }} min</div>
                                                         @php
-                                                            $requested = $slot->requests->where('coaching_timer_manuscript_id', $coachingTimer->id)->isNotEmpty();
+                                                            $requested = $slot->requests->whereIn('coaching_timer_manuscript_id', $coachingTimers->pluck('id'))->isNotEmpty();
                                                         @endphp
                                                         @if($requested)
                                                             <div class="mt-2 text-muted">Requested</div>
                                                         @else
-                                                            <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
-                                                                @csrf
-                                                                <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
-                                                                <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
-                                                                <button type="submit" class="btn btn-primary btn-sm">Book</button>
-                                                            </form>
+                                                            @if($coachingTimers->count() === 1)
+                                                                <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
+                                                                    @csrf
+                                                                    <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimers->first()->id }}">
+                                                                    <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
+                                                                    <button type="submit" class="btn btn-primary btn-sm">Book</button>
+                                                                </form>
+                                                            @else
+                                                                <button type="button" class="btn btn-primary btn-sm book-btn" data-slot-id="{{ $slot->id }}">Book</button>
+                                                            @endif
                                                         @endif
                                                     </div>
                                                 @endforeach
@@ -85,11 +89,43 @@
                     @endforeach
                 @else
                     <p>Ingen coaching time tilgjengelig.</p>
-                @endisset
+                @endif
             </div>
         </div>
     </div>
 </div>
+@if($coachingTimers->count() > 1)
+    <div class="modal fade" id="selectCoachingTimerModal" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Select Coaching Time</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <form method="POST" action="{{ route('learner.coaching-time.request') }}">
+                    @csrf
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label for="modal_coaching_timer_id">Coaching Time</label>
+                            <select name="coaching_timer_id" id="modal_coaching_timer_id" class="form-control">
+                                @foreach($coachingTimers as $timer)
+                                    <option value="{{ $timer->id }}">Coaching Time #{{ $loop->iteration }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <input type="hidden" name="editor_time_slot_id" id="modal_editor_time_slot_id">
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                        <button type="submit" class="btn btn-primary">Book</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endif
 @endsection
 
 @section('scripts')
@@ -141,6 +177,16 @@
 
             updateButtons();
         });
+
+        @if($coachingTimers->count() > 1)
+        document.querySelectorAll('.book-btn').forEach(function(btn){
+            btn.addEventListener('click', function(){
+                const slotId = this.dataset.slotId;
+                document.getElementById('modal_editor_time_slot_id').value = slotId;
+                $('#selectCoachingTimerModal').modal('show');
+            });
+        });
+        @endif
     });
 </script>
 @endsection

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -102,22 +102,10 @@
                     <h3>Book Redaksjonstime</h3>
                     <span>Velg redaktør og tid for å booke din neste sesjon.</span>
                     
-                    @if($coachingTimers->count() === 1)
-                        <a href="{{ route('learner.coaching-time.available', ['coaching_timer_id' => $coachingTimers->first()->id]) }}" class="btn black-btn mt-4">
+                    @if($coachingTimers->count() >= 1)
+                        <a href="{{ route('learner.coaching-time.available') }}" class="btn black-btn mt-4">
                             Se Tilgjengelige Tider
                         </a>
-                    @elseif($coachingTimers->count() > 1)
-                        <form action="{{ route('learner.coaching-time.available') }}" method="GET" class="mt-4">
-                            <div class="form-group">
-                                <label for="coaching_timer_id">Velg Coaching Time</label>
-                                <select name="coaching_timer_id" id="coaching_timer_id" class="form-control">
-                                    @foreach($coachingTimers as $timer)
-                                        <option value="{{ $timer->id }}">Coaching Time #{{ $loop->iteration }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                            <button type="submit" class="btn black-btn mt-2">Se Tilgjengelige Tider</button>
-                        </form>
                     @else
                         <p>Ingen coaching time tilgjengelig.</p>
                     @endif


### PR DESCRIPTION
## Summary
- Remove coaching timer selection from main coaching time page
- Collect all coaching timers in controller and expose to views
- Show modal to pick coaching timer when booking if multiple timers exist

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b945ceb4a4832589c4257ac8d145ae