### PR TITLE
fix: refine pending coaching slot handling

### DIFF
--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -30,7 +30,10 @@
 
                 @php
                     $availableTimers = $coachingTimers->filter(fn($t) => $t->requests->isEmpty());
-                    $hasAvailableTimer = $availableTimers->isNotEmpty();
+                    $hasPendingRequest = $coachingTimers->pluck('requests')
+                        ->flatten()
+                        ->where('status', 'pending')
+                        ->isNotEmpty();
                 @endphp
 
                 @if($coachingTimers->count())
@@ -71,8 +74,10 @@
                                                                 ->whereIn('coaching_timer_manuscript_id', $coachingTimers->pluck('id'))
                                                                 ->isNotEmpty();
                                                         @endphp
-                                                        @if($requested || !$hasAvailableTimer)
+                                                        @if($requested)
                                                             <div class="mt-2 text-muted">Requested</div>
+                                                        @elseif($hasPendingRequest)
+                                                            {{-- No action available while another request is pending --}}
                                                         @else
                                                             @if($coachingTimers->count() === 1)
                                                                 <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">


### PR DESCRIPTION
## Summary
- prevent multiple pending coaching slots from showing as requested
- hide booking buttons when another request is pending

## Testing
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4c15c94083258c8008b0f898f4c5