### PR TITLE
Move coaching time selection to dropdown

### DIFF
--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -29,7 +29,6 @@
                 <h1 class="page-title">Available Time Slots</h1>
 
                 @php
-                    $availableTimers = $coachingTimers->filter(fn($t) => $t->requests->isEmpty());
                     $hasPendingRequest = $coachingTimers->pluck('requests')
                         ->flatten()
                         ->where('status', 'pending')
@@ -78,17 +77,13 @@
                                                             <div class="mt-2 text-muted">Requested</div>
                                                         @elseif($hasPendingRequest)
                                                             {{-- No action available while another request is pending --}}
-                                                        @else
-                                                            @if($coachingTimers->count() === 1)
-                                                                <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
-                                                                    @csrf
-                                                                    <input type="hidden" name="coaching_timer_id" value="{{ $availableTimers->first()->id }}">
-                                                                    <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
-                                                                    <button type="submit" class="btn btn-primary btn-sm">Book</button>
-                                                                </form>
-                                                            @else
-                                                                <button type="button" class="btn btn-primary btn-sm book-btn" data-slot-id="{{ $slot->id }}">Book</button>
-                                                            @endif
+                                                        @elseif($coachingTimer)
+                                                            <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
+                                                                @csrf
+                                                                <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                                                                <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
+                                                                <button type="submit" class="btn btn-primary btn-sm">Book</button>
+                                                            </form>
                                                         @endif
                                                     </div>
                                                 @endforeach
@@ -106,40 +101,6 @@
         </div>
     </div>
 </div>
-@if($coachingTimers->count() > 1)
-<!-- Hidden trigger -->
-<button id="hiddenTrigger" type="button" data-toggle="modal" data-target="#selectCoachingTimerModal" style="display:none;"></button>
-    <div id="selectCoachingTimerModal" class="modal fade" role="dialog" data-backdrop="static">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">Select Coaching Time</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <form method="POST" action="{{ route('learner.coaching-time.request') }}">
-                    @csrf
-                    <div class="modal-body">
-                        <div class="form-group">
-                            <label for="modal_coaching_timer_id">Coaching Time</label>
-                            <select name="coaching_timer_id" id="modal_coaching_timer_id" class="form-control">
-                                @foreach($availableTimers as $timer)
-                                    <option value="{{ $timer->id }}">Coaching Time #{{ $loop->iteration }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <input type="hidden" name="editor_time_slot_id" id="modal_editor_time_slot_id">
-                    </div>
-                    <div class="modal-footer">
-                        <button type="submit" class="btn btn-primary">Book</button>
-                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
-                    </div>
-                </form>
-            </div>
-        </div>
-    </div>
-@endif
 @endsection
 
 @section('scripts')
@@ -192,18 +153,6 @@
             updateButtons();
         });
 
-        @if($coachingTimers->count() > 1)
-        document.querySelectorAll('.book-btn').forEach(function(btn){
-            btn.addEventListener('click', function(){
-                const slotId = this.dataset.slotId;
-                document.getElementById('modal_editor_time_slot_id').value = slotId;
-
-                // Simulate clicking the hidden trigger (Bootstrap handles it properly)
-                document.getElementById('hiddenTrigger').click();
-                //$('#selectCoachingTimerModal').modal('show');
-            });
-        });
-        @endif
     });
 </script>
 @endsection

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -103,9 +103,23 @@
                     <span>Velg redaktør og tid for å booke din neste sesjon.</span>
                     
                     @if($coachingTimers->count() >= 1)
-                        <a href="{{ route('learner.coaching-time.available') }}" class="btn black-btn mt-4">
-                            Se Tilgjengelige Tider
-                        </a>
+                        <form method="GET" action="{{ route('learner.coaching-time.available') }}">
+                            @if($coachingTimers->count() > 1)
+                                <div class="form-group mt-3">
+                                    <label for="coaching_timer_id">Coaching Time</label>
+                                    <select name="coaching_timer_id" id="coaching_timer_id" class="form-control">
+                                        @foreach($coachingTimers as $timer)
+                                            <option value="{{ $timer->id }}">Coaching Time #{{ $loop->iteration }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                            @else
+                                <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimers->first()->id }}">
+                            @endif
+                            <button type="submit" class="btn black-btn mt-4">
+                                Se Tilgjengelige Tider
+                            </button>
+                        </form>
                     @else
                         <p>Ingen coaching time tilgjengelig.</p>
                     @endif


### PR DESCRIPTION
## Summary
- Replace modal-based coaching time selection with a dropdown on the main coaching page
- Streamline booking page by removing modal logic and using selected coaching time directly

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba582042a48325b1cf4b7194536faf