### PR TITLE
Check pending requests per coaching timer

### DIFF
--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -29,10 +29,7 @@
                 <h1 class="page-title">Available Time Slots</h1>
 
                 @php
-                    $hasPendingRequest = $coachingTimers->pluck('requests')
-                        ->flatten()
-                        ->where('status', 'pending')
-                        ->isNotEmpty();
+                    $hasPendingRequest = $coachingTimer && $coachingTimer->requests->where('status', 'pending')->isNotEmpty();
                 @endphp
 
                 @if($coachingTimers->count())


### PR DESCRIPTION
## Summary
- scope pending request check to the selected coaching timer so other timers remain bookable

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --no-progress --no-interaction` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5ae99fa883258dae4496dc0d11d7