### PR TITLE
Decline conflicting coaching requests

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -84,6 +84,11 @@ class CoachingTimeController extends Controller
         $request->status = 'accepted';
         $request->save();
 
+        CoachingTimeRequest::where('editor_time_slot_id', $request->editor_time_slot_id)
+            ->where('id', '!=', $request->id)
+            ->where('status', 'pending')
+            ->update(['status' => 'declined']);
+
         $manuscript = $request->manuscript;
         $manuscript->editor_id = Auth::id();
         $manuscript->editor_time_slot_id = $request->editor_time_slot_id;


### PR DESCRIPTION
## Summary
- ensure approving a coaching request declines other pending requests for the same time slot

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8462ec648325b5b1f4e78ec38fc7