### PR TITLE
Fix editor coaching request time display

### DIFF
--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -158,7 +158,7 @@
                                 @forelse($requests as $req)
                                     <tr>
                                         <td>{{ $req->manuscript->user->name }}</td>
-                                        <td>{{ \Carbon\Carbon::parse($req->slot->date)->format('d.m.Y') }} {{ $req->slot->start_time }}</td>
+                                        <td class="slot-time" data-time="{{ \Carbon\Carbon::parse($req->slot->date.' '.$req->slot->start_time, 'UTC')->toIso8601String() }}"></td>
                                         <td>
                                             <form method="POST" action="{{ route('editor.coaching-time.request.accept', $req->id) }}" class="d-inline">
                                                 @csrf
@@ -180,4 +180,21 @@
             </div>
         </div>
     </div>
+@endsection
+
+@section('scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.slot-time').forEach(function (el) {
+            const dt = new Date(el.dataset.time);
+            const datePart = dt.toLocaleDateString('no-NO');
+            const timePart = dt.toLocaleTimeString('no-NO', {
+                hour: '2-digit',
+                minute: '2-digit',
+                hour12: false
+            });
+            el.textContent = `${datePart} ${timePart}`;
+        });
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- use ISO timestamps for student coaching-time requests
- render localised date/time client-side for editor view

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68ba88eaeb188325bc832963de12d22d