### PR TITLE
Restrict coaching slot booking to matching plan duration

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5751,6 +5751,14 @@ class LearnerController extends Controller
             'editor_time_slot_id' => 'required|exists:editor_time_slots,id',
         ]);
 
+        $timer = CoachingTimerManuscript::find($data['coaching_timer_id']);
+        $slot  = EditorTimeSlot::find($data['editor_time_slot_id']);
+
+        $requiredDuration = $timer->plan_type == 1 ? 60 : 30;
+        if ($slot->duration != $requiredDuration) {
+            return redirect()->back()->with('error', 'Selected time slot duration does not match your plan.');
+        }
+
         $exists = CoachingTimeRequest::where('coaching_timer_manuscript_id', $data['coaching_timer_id'])
             ->where('editor_time_slot_id', $data['editor_time_slot_id'])
             ->exists();

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -74,13 +74,15 @@
                                                             <div class="mt-2 text-muted">Requested</div>
                                                         @elseif($hasPendingRequest)
                                                             {{-- No action available while another request is pending --}}
-                                                        @elseif($coachingTimer)
+                                                        @elseif($coachingTimer && (($coachingTimer->plan_type == 1 && $slot->duration == 60) || ($coachingTimer->plan_type == 2 && $slot->duration == 30)))
                                                             <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
                                                                 @csrf
                                                                 <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
                                                                 <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
                                                                 <button type="submit" class="btn btn-primary btn-sm">Book</button>
                                                             </form>
+                                                        @elseif($coachingTimer)
+                                                            <div class="mt-2 text-muted">Unavailable</div>
                                                         @endif
                                                     </div>
                                                 @endforeach


### PR DESCRIPTION
## Summary
- prevent booking slots with mismatched durations in coaching time availability page
- validate slot duration against learner plan on coaching time request

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, needs GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9abdf9c88325bbaf29a03c51f038