### PR TITLE
Hide past coaching time slots

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5732,9 +5732,18 @@ class LearnerController extends Controller
             $coachingTimer = $coachingTimers->first();
         }
 
+        $now = Carbon::now('UTC');
+
         $editors = EditorTimeSlot::with(['editor', 'requests'])
             ->whereDoesntHave('requests', function ($q) {
                 $q->where('status', 'accepted');
+            })
+            ->where(function ($q) use ($now) {
+                $q->where('date', '>', $now->toDateString())
+                    ->orWhere(function ($q) use ($now) {
+                        $q->where('date', $now->toDateString())
+                            ->where('start_time', '>=', $now->toTimeString());
+                    });
             })
             ->orderBy('date')
             ->orderBy('start_time')


### PR DESCRIPTION
## Summary
- Filter available coaching time slots to exclude dates and times that are already in the past.

## Testing
- `php -l app/Http/Controllers/Frontend/LearnerController.php`
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be40500ee483258941a1141d3f987d