### PR TITLE
Handle declined coaching time requests as unavailable

### DIFF
--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -69,9 +69,16 @@
                                                                 ->where('status', 'pending')
                                                                 ->whereIn('coaching_timer_manuscript_id', $coachingTimers->pluck('id'))
                                                                 ->isNotEmpty();
+
+                                                            $declined = $slot->requests
+                                                                ->where('status', 'declined')
+                                                                ->whereIn('coaching_timer_manuscript_id', $coachingTimers->pluck('id'))
+                                                                ->isNotEmpty();
                                                         @endphp
                                                         @if($requested)
                                                             <div class="mt-2 text-muted">Requested</div>
+                                                        @elseif($declined)
+                                                            <div class="mt-2 text-muted">Unavailable</div>
                                                         @elseif($hasPendingRequest)
                                                             {{-- No action available while another request is pending --}}
                                                         @elseif($coachingTimer && (($coachingTimer->plan_type == 1 && $slot->duration == 60) || ($coachingTimer->plan_type == 2 && $slot->duration == 30)))


### PR DESCRIPTION
## Summary
- Show coaching slots as Unavailable when a learner's request was declined

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be53b75a7c832584bf61bad2619cb4