### PR TITLE
Improve editor coaching calendar for booked slots

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -30,18 +30,34 @@ class CoachingTimeController extends Controller
 
     public function fetchTimeSlot()
     {
-        $slots = EditorTimeSlot::where('editor_id', Auth::user()->id)->get();
+        $slots = EditorTimeSlot::where('editor_id', Auth::user()->id)
+            ->with(['requests.manuscript.user'])
+            ->get();
 
         $events = $slots->map(function ($slot) {
             $startUtc = Carbon::parse("{$slot->date} {$slot->start_time}", 'UTC');
             $endUtc   = (clone $startUtc)->addMinutes($slot->duration);
 
-            return [
+            $event = [
                 'id'    => $slot->id,
                 'title' => $slot->duration . ' min',
                 'start' => $startUtc->toIso8601ZuluString(),
                 'end'   => $endUtc->toIso8601ZuluString(),
             ];
+
+            $accepted = $slot->requests->firstWhere('status', 'accepted');
+            if ($accepted) {
+                $event['backgroundColor'] = '#28a745';
+                $event['borderColor'] = '#28a745';
+                $event['textColor'] = '#ffffff';
+                $event['extendedProps'] = [
+                    'booked'   => true,
+                    'student'  => $accepted->manuscript->user->full_name ?? null,
+                    'duration' => $slot->duration,
+                ];
+            }
+
+            return $event;
         });
 
         return response()->json($events);

--- a/resources/views/editor/coaching-time/calendar.blade.php
+++ b/resources/views/editor/coaching-time/calendar.blade.php
@@ -21,6 +21,26 @@
         <div id="calendar"></div>
     </div>
 </div>
+
+<div class="modal fade" id="slotDetailsModal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">Coaching Time Details</h4>
+            </div>
+            <div class="modal-body">
+                <p><strong>Student:</strong> <span id="slotStudent"></span></p>
+                <p><strong>Start:</strong> <span id="slotStart"></span></p>
+                <p><strong>End:</strong> <span id="slotEnd"></span></p>
+                <p><strong>Duration:</strong> <span id="slotDuration"></span></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
 @endsection
 
 @section('scripts')
@@ -99,46 +119,79 @@
                     <div style="font-size: 12px;">${duration}min</div>
                 `;
 
-                // right side (delete ×)
-                let closeBtn = document.createElement('span');
-                closeBtn.innerHTML = '&times;';
-                closeBtn.style.cursor = 'pointer';
-                closeBtn.style.color = 'white';
-                closeBtn.style.fontWeight = 'bold';
-
-                // 👇 increase size of the ×
-                closeBtn.style.fontSize = '20px';      // bigger font
-                closeBtn.style.lineHeight = '1';       // keeps it compact
-                closeBtn.style.marginLeft = '10px';    // spacing from text
-                closeBtn.style.userSelect = 'none';    // prevent accidental text selection
-
-                closeBtn.title = 'Delete slot';
-
-                closeBtn.onclick = function(e) {
-                    e.stopPropagation(); // don’t trigger eventClick
-
-                    if (confirm(`Delete this slot?\n${startTxt} – ${endTxt}`)) {
-                    fetch("{{ url('/coaching-time/time-slots') }}/" + arg.event.id, {
-                        method: "DELETE",
-                        headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" }
-                    })
-                    .then(res => res.json())
-                    .then(data => {
-                        if (data.success) {
-                            arg.event.remove();
-                            toastr.success('Your time slot was successfully deleted.', "Success");
-                        }
-                    });
-                    }
-                };
-
                 wrapper.appendChild(left);
-                wrapper.appendChild(closeBtn);
+
+                if (arg.event.extendedProps.booked) {
+                    let viewBtn = document.createElement('span');
+                    viewBtn.innerHTML = 'View Details';
+                    viewBtn.style.cursor = 'pointer';
+                    viewBtn.style.color = 'white';
+                    viewBtn.style.fontSize = '12px';
+
+                    viewBtn.onclick = function(e) {
+                        e.stopPropagation();
+                        showSlotDetails(arg.event);
+                    };
+
+                    wrapper.appendChild(viewBtn);
+                } else {
+                    let closeBtn = document.createElement('span');
+                    closeBtn.innerHTML = '&times;';
+                    closeBtn.style.cursor = 'pointer';
+                    closeBtn.style.color = 'white';
+                    closeBtn.style.fontWeight = 'bold';
+
+                    closeBtn.style.fontSize = '20px';
+                    closeBtn.style.lineHeight = '1';
+                    closeBtn.style.marginLeft = '10px';
+                    closeBtn.style.userSelect = 'none';
+
+                    closeBtn.title = 'Delete slot';
+
+                    closeBtn.onclick = function(e) {
+                        e.stopPropagation();
+
+                        if (confirm(`Delete this slot?\n${startTxt} – ${endTxt}`)) {
+                        fetch("{{ url('/coaching-time/time-slots') }}/" + arg.event.id, {
+                            method: "DELETE",
+                            headers: { "X-CSRF-TOKEN": "{{ csrf_token() }}" }
+                        })
+                        .then(res => res.json())
+                        .then(data => {
+                            if (data.success) {
+                                arg.event.remove();
+                                toastr.success('Your time slot was successfully deleted.', "Success");
+                            }
+                        });
+                        }
+                    };
+
+                    wrapper.appendChild(closeBtn);
+                }
 
                 return { domNodes: [wrapper] };
+            },
+
+            eventClick: function(info) {
+                if (info.event.extendedProps.booked) {
+                    showSlotDetails(info.event);
+                }
             }
 
         });
+
+        function showSlotDetails(event) {
+            let start = new Date(event.start);
+            let end   = new Date(event.end);
+            let fmt = { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
+
+            document.getElementById('slotStudent').textContent = event.extendedProps.student || '';
+            document.getElementById('slotStart').textContent = start.toLocaleString([], fmt);
+            document.getElementById('slotEnd').textContent = end.toLocaleString([], fmt);
+            document.getElementById('slotDuration').textContent = (event.extendedProps.duration || ((end - start)/60000)) + ' min';
+
+            $('#slotDetailsModal').modal('show');
+        }
 
         calendar.render();
     });


### PR DESCRIPTION
## Summary
- Highlight accepted time slots with a green background and mark them as booked
- Replace deletion controls with a "View Details" link that opens a details modal
- Provide student and time information in the modal for booked slots

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68be764a70488325a0ad3c02d4e7eea9