### PR TITLE
Show accepted editor count on coaching time page

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5713,7 +5713,12 @@ class LearnerController extends Controller
             ->get()
             ->groupBy('editor_id');
 
-        return view('frontend.learner.coaching-time', compact('editors', 'coachingTimers'));
+        $bookedEditorsCount = CoachingTimerManuscript::where('user_id', Auth::id())
+            ->whereNotNull('editor_id')
+            ->distinct('editor_id')
+            ->count('editor_id');
+
+        return view('frontend.learner.coaching-time', compact('editors', 'coachingTimers', 'bookedEditorsCount'));
     }
 
     public function availableCoachingTime(Request $request)

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -73,7 +73,7 @@
             <div class="col-sm-3">
                 <div class="stats-card text-center">
                     <p>Mine Redaktører</p>
-                    <h2>{{ $editors->count() }}</h2>
+                    <h2>{{ $bookedEditorsCount }}</h2>
                 </div>
             </div>
             <div class="col-sm-3">


### PR DESCRIPTION
## Summary
- count distinct editors who accepted a learner's time slots
- display that count in "Mine Redaktører" on the coaching-time page

## Testing
- `composer install --no-interaction --no-progress` *(failed: CONNECT tunnel failed, response 403)*
- `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf967d5d3883259b37abc303dd01b7