### PR TITLE
Show upcoming coaching sessions

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5698,7 +5698,7 @@ class LearnerController extends Controller
         ], $httpcode);
     }
 
-    public function coachingTime()
+    public function coachingTime(Request $request)
     {
         $coachingTimers = CoachingTimerManuscript::where('user_id', Auth::id())
             ->whereNull('editor_id')
@@ -5718,7 +5718,21 @@ class LearnerController extends Controller
             ->distinct('editor_id')
             ->count('editor_id');
 
-        return view('frontend.learner.coaching-time', compact('editors', 'coachingTimers', 'bookedEditorsCount'));
+        $bookedSessions = CoachingTimerManuscript::where('user_id', Auth::id())
+            ->whereNotNull('approved_date')
+            ->with('editor')
+            ->orderBy('approved_date')
+            ->get();
+
+        $showAllSessions = $request->boolean('all');
+
+        return view('frontend.learner.coaching-time', compact(
+            'editors',
+            'coachingTimers',
+            'bookedEditorsCount',
+            'bookedSessions',
+            'showAllSessions'
+        ));
     }
 
     public function availableCoachingTime(Request $request)

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -128,7 +128,29 @@
             <div class="col-md-6">
                 <div class="stats-card text-left">
                     <h3>Mine Sesjoner</h3>
-                    <span>Ingen kommende sesjoner.</span>
+                    @php
+                        $sessionsToShow = $showAllSessions ? $bookedSessions : $bookedSessions->take(2);
+                    @endphp
+                    @if($sessionsToShow->isEmpty())
+                        <span>Ingen kommende sesjoner.</span>
+                    @else
+                        <ul class="list-unstyled mb-0">
+                            @foreach($sessionsToShow as $session)
+                                @php
+                                    $date = \Carbon\Carbon::parse($session->approved_date);
+                                    $dateLabel = $date->isToday() ? 'I dag' : $date->format('d.m.Y');
+                                    $duration = $session->plan_type == 1 ? '60 min' : '30 min';
+                                @endphp
+                                <li class="mb-3">
+                                    <div>{{ $dateLabel }} {{ $date->format('H:i') }}</div>
+                                    <div>{{ $duration }} med {{ optional($session->editor)->full_name }}</div>
+                                </li>
+                            @endforeach
+                        </ul>
+                        @if(!$showAllSessions && $bookedSessions->count() > 2)
+                            <a href="{{ route('learner.coaching-time', ['all' => 1]) }}" class="btn black-btn mt-3">Se Alle Sesjoner</a>
+                        @endif
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- display two nearest approved coaching sessions and a "See All Sessions" button when more exist
- load booked coaching sessions in learner controller with optional flag to view all

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd3d68350832584013b839e2043d1