### PR TITLE
Display friendly labels for upcoming coaching sessions

### DIFF
--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -135,7 +135,9 @@
                             @foreach($bookedSessions as $session)
                                 @php
                                     $date = \Carbon\Carbon::parse($session->approved_date);
-                                    $dateLabel = $date->isToday() ? 'I dag' : $date->format('d.m.Y');
+                                    $dateLabel = $date->isToday()
+                                        ? 'I dag'
+                                        : ($date->isTomorrow() ? 'I morgen' : $date->format('d.m.Y'));
                                     $duration = $session->plan_type == 1 ? '60 min' : '30 min';
                                 @endphp
                                 <li class="mb-3 {{ $loop->iteration > 2 ? 'd-none extra-session' : '' }}">


### PR DESCRIPTION
## Summary
- Show `I dag` for sessions happening today and `I morgen` for tomorrow
- Fall back to full date for later sessions in "Mine Sesjoner"

## Testing
- `composer install` *(fails: GitHub token required)*
- `./vendor/bin/phpunit` *(fails: file not found; dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe1655c788325a009381c6b2ed171