### PR TITLE
Use accepted editor time slot for learner sessions

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5719,10 +5719,12 @@ class LearnerController extends Controller
             ->count('editor_id');
 
         $bookedSessions = CoachingTimerManuscript::where('user_id', Auth::id())
-            ->whereNotNull('approved_date')
-            ->with('editor')
-            ->orderBy('approved_date')
-            ->get();
+            ->whereNotNull('editor_time_slot_id')
+            ->with(['editor', 'timeSlot'])
+            ->get()
+            ->sortBy(function ($session) {
+                return $session->timeSlot->date . ' ' . $session->timeSlot->start_time;
+            });
 
         return view('frontend.learner.coaching-time', compact(
             'editors',

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -134,7 +134,10 @@
                         <ul id="sessions-list" class="list-unstyled mb-0">
                             @foreach($bookedSessions as $session)
                                 @php
-                                    $date = \Carbon\Carbon::parse($session->approved_date);
+                                    $date = \Carbon\Carbon::parse(
+                                        $session->timeSlot->date.' '.$session->timeSlot->start_time,
+                                        'UTC'
+                                    )->setTimezone(config('app.timezone'));
                                     $dateLabel = $date->isToday()
                                         ? 'I dag'
                                         : ($date->isTomorrow() ? 'I morgen' : $date->format('d.m.Y'));


### PR DESCRIPTION
## Summary
- Show booked coaching sessions using the editor time slot rather than `approved_date`
- Display session date/time based on accepted slot in "Mine Sesjoner"

## Testing
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*
- `composer install` *(fails: GitHub API 403 requiring token)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe4077a70832587406c39f14959a5