### PR TITLE
Filter learner coaching sessions by status and date

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5720,6 +5720,12 @@ class LearnerController extends Controller
 
         $bookedSessions = CoachingTimerManuscript::where('user_id', Auth::id())
             ->whereNotNull('editor_time_slot_id')
+            ->where(function ($q) {
+                $q->where('status', 0)
+                    ->orWhereHas('timeSlot', function ($q) {
+                        $q->where('date', '>=', now()->toDateString());
+                    });
+            })
             ->with(['editor', 'timeSlot'])
             ->get()
             ->sortBy(function ($session) {


### PR DESCRIPTION
## Summary
- Show only coaching sessions that are either pending (status 0) or scheduled for today/future in learner "Mine Sesjoner" view

## Testing
- `php -l app/Http/Controllers/Frontend/LearnerController.php`
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0dbf1d2148325a22997d520c30af7