### PR TITLE
Display weekday names for upcoming sessions

### DIFF
--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -138,9 +138,15 @@
                                         $session->timeSlot->date.' '.$session->timeSlot->start_time,
                                         'UTC'
                                     )->setTimezone(config('app.timezone'));
-                                    $dateLabel = $date->isToday()
-                                        ? 'I dag'
-                                        : ($date->isTomorrow() ? 'I morgen' : $date->format('d.m.Y'));
+                                    if ($date->isToday()) {
+                                        $dateLabel = 'I dag';
+                                    } elseif ($date->isTomorrow()) {
+                                        $dateLabel = 'I morgen';
+                                    } elseif ($date->isSameWeek(\Carbon\Carbon::now(config('app.timezone')))) {
+                                        $dateLabel = ucfirst($date->locale(app()->getLocale())->dayName);
+                                    } else {
+                                        $dateLabel = $date->format('d.m.Y');
+                                    }
                                     $duration = $session->plan_type == 1 ? '60 min' : '30 min';
                                 @endphp
                                 <li class="mb-3 {{ $loop->iteration > 2 ? 'd-none extra-session' : '' }}">


### PR DESCRIPTION
## Summary
- Show weekday name for upcoming coaching sessions within current week.

## Testing
- `npm test` (fails: Missing script "test")
- `composer install` (fails: requires GitHub token)


------
https://chatgpt.com/codex/tasks/task_e_68c0e43b9cac8325821868d41222ccb4