### PR TITLE
Restrict coaching time access to owner

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5754,7 +5754,11 @@ class LearnerController extends Controller
 
         $coachingTimer = null;
         if ($request->filled('coaching_timer_id')) {
-            $coachingTimer = $coachingTimers->where('id', $request->input('coaching_timer_id'))->first();
+            $coachingTimer = $coachingTimers->firstWhere('id', $request->input('coaching_timer_id'));
+
+            if (!$coachingTimer) {
+                return redirect()->route('learner.coaching-time');
+            }
         } elseif ($coachingTimers->count() === 1) {
             $coachingTimer = $coachingTimers->first();
         }


### PR DESCRIPTION
## Summary
- Validate `coaching_timer_id` against the logged-in user
- Redirect unauthorized access to `/account/coaching-time`

## Testing
- `php -l app/Http/Controllers/Frontend/LearnerController.php`
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub token)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1339513fc83258ab8da4a31b5a64d