### PR TITLE
Add help-with modal to coaching time booking

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5789,6 +5789,7 @@ class LearnerController extends Controller
         $data = $request->validate([
             'coaching_timer_id'   => 'required|exists:coaching_timer_manuscripts,id',
             'editor_time_slot_id' => 'required|exists:editor_time_slots,id',
+            'help_with'           => 'nullable|string',
         ]);
 
         $timer = CoachingTimerManuscript::find($data['coaching_timer_id']);
@@ -5799,21 +5800,31 @@ class LearnerController extends Controller
             return redirect()->back()->with('error', 'Selected time slot duration does not match your plan.');
         }
 
-        $exists = CoachingTimeRequest::where('coaching_timer_manuscript_id', $data['coaching_timer_id'])
-            ->where('editor_time_slot_id', $data['editor_time_slot_id'])
+        $exists = CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
+            ->where('status', 'accepted')
             ->exists();
 
         if ($exists) {
-            return redirect()->back()->with('error', 'You have already requested this time slot.');
+            return redirect()->back()->with('error', 'This time slot has already been booked.');
         }
 
-        CoachingTimeRequest::create([
+        $requestRecord = CoachingTimeRequest::create([
             'coaching_timer_manuscript_id' => $data['coaching_timer_id'],
             'editor_time_slot_id'          => $data['editor_time_slot_id'],
-            'status'                       => 'pending',
+            'status'                       => 'accepted',
         ]);
 
-        return redirect()->route('learner.coaching-time')->with('success', 'Time slot requested.');
+        CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
+            ->where('id', '!=', $requestRecord->id)
+            ->where('status', 'pending')
+            ->update(['status' => 'declined']);
+
+        $timer->help_with = $data['help_with'] ?? null;
+        $timer->editor_id = $slot->editor_id;
+        $timer->editor_time_slot_id = $slot->id;
+        $timer->save();
+
+        return redirect()->route('learner.coaching-time')->with('success', 'Time slot booked.');
     }
 
     public function currentUser()

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -82,12 +82,7 @@
                                                         @elseif($hasPendingRequest)
                                                             {{-- No action available while another request is pending --}}
                                                         @elseif($coachingTimer && (($coachingTimer->plan_type == 1 && $slot->duration == 60) || ($coachingTimer->plan_type == 2 && $slot->duration == 30)))
-                                                            <form method="POST" action="{{ route('learner.coaching-time.request') }}" class="mt-2">
-                                                                @csrf
-                                                                <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
-                                                                <input type="hidden" name="editor_time_slot_id" value="{{ $slot->id }}">
-                                                                <button type="submit" class="btn btn-primary btn-sm">Book</button>
-                                                            </form>
+                                                            <button type="button" class="btn btn-primary btn-sm mt-2 book-slot-btn" data-slot-id="{{ $slot->id }}">Book</button>
                                                         @elseif($coachingTimer)
                                                             <div class="mt-2 text-muted">Unavailable</div>
                                                         @endif
@@ -103,6 +98,28 @@
                 @else
                     <p class="mt-4">Ingen coaching time tilgjengelig.</p>
                 @endif
+            </div>
+        </div>
+    </div>
+
+    <div id="bookSlotModal" class="modal fade" role="dialog">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title">{{ trans('site.learner.help-with-text') }}</h3>
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <form action="{{ route('learner.coaching-time.request') }}" method="POST" id="bookSlotForm">
+                        @csrf
+                        <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                        <input type="hidden" name="editor_time_slot_id" value="">
+                        <textarea name="help_with" cols="30" rows="10" class="form-control"></textarea>
+                        <div class="text-right mt-4">
+                            <button type="submit" class="btn btn-success">{{ trans('site.front.submit') }}</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
@@ -157,6 +174,16 @@
             });
 
             updateButtons();
+        });
+
+        document.querySelectorAll('.book-slot-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                const slotId = this.dataset.slotId;
+                const modal = $('#bookSlotModal');
+                modal.find('[name=editor_time_slot_id]').val(slotId);
+                modal.find('[name=help_with]').val('');
+                modal.modal('show');
+            });
         });
 
     });


### PR DESCRIPTION
## Summary
- show help-with modal before booking a coaching time slot
- auto-accept coaching time bookings and store help request

## Testing
- `composer install` (fails: CONNECT tunnel failed 403)
- `vendor/bin/phpunit` (fails: No such file or directory)
- `npm test` (fails: Missing script "test")
- `php -l app/Http/Controllers/Frontend/LearnerController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c23ef0f0e883259ec0db9b5dbc5947