### PR TITLE
Add help-with modal to coaching time booking

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5800,29 +5800,36 @@ class LearnerController extends Controller
             return redirect()->back()->with('error', 'Selected time slot duration does not match your plan.');
         }
 
-        $exists = CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
-            ->where('status', 'accepted')
-            ->exists();
+        try {
+            DB::transaction(function () use ($data, $timer, $slot) {
+                $exists = CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
+                    ->where('status', 'accepted')
+                    ->lockForUpdate()
+                    ->exists();
 
-        if ($exists) {
+                if ($exists) {
+                    throw new \RuntimeException('Slot already booked');
+                }
+
+                $requestRecord = CoachingTimeRequest::create([
+                    'coaching_timer_manuscript_id' => $data['coaching_timer_id'],
+                    'editor_time_slot_id'          => $data['editor_time_slot_id'],
+                    'status'                       => 'accepted',
+                ]);
+
+                CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
+                    ->where('id', '!=', $requestRecord->id)
+                    ->where('status', 'pending')
+                    ->update(['status' => 'declined']);
+
+                $timer->help_with = $data['help_with'] ?? null;
+                $timer->editor_id = $slot->editor_id;
+                $timer->editor_time_slot_id = $slot->id;
+                $timer->save();
+            });
+        } catch (\RuntimeException $e) {
             return redirect()->back()->with('error', 'This time slot has already been booked.');
         }
-
-        $requestRecord = CoachingTimeRequest::create([
-            'coaching_timer_manuscript_id' => $data['coaching_timer_id'],
-            'editor_time_slot_id'          => $data['editor_time_slot_id'],
-            'status'                       => 'accepted',
-        ]);
-
-        CoachingTimeRequest::where('editor_time_slot_id', $data['editor_time_slot_id'])
-            ->where('id', '!=', $requestRecord->id)
-            ->where('status', 'pending')
-            ->update(['status' => 'declined']);
-
-        $timer->help_with = $data['help_with'] ?? null;
-        $timer->editor_id = $slot->editor_id;
-        $timer->editor_time_slot_id = $slot->id;
-        $timer->save();
 
         return redirect()->route('learner.coaching-time')->with('success', 'Time slot booked.');
     }

--- a/resources/views/frontend/learner/coaching-time-available.blade.php
+++ b/resources/views/frontend/learner/coaching-time-available.blade.php
@@ -102,27 +102,29 @@
         </div>
     </div>
 
-    <div id="bookSlotModal" class="modal fade" role="dialog">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h3 class="modal-title">{{ trans('site.learner.help-with-text') }}</h3>
-                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                </div>
-                <div class="modal-body">
-                    <form action="{{ route('learner.coaching-time.request') }}" method="POST" id="bookSlotForm">
-                        @csrf
-                        <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
-                        <input type="hidden" name="editor_time_slot_id" value="">
-                        <textarea name="help_with" cols="30" rows="10" class="form-control"></textarea>
-                        <div class="text-right mt-4">
-                            <button type="submit" class="btn btn-success">{{ trans('site.front.submit') }}</button>
-                        </div>
-                    </form>
+    @if ($coachingTimer)
+        <div id="bookSlotModal" class="modal fade" role="dialog">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h3 class="modal-title">{{ trans('site.learner.help-with-text') }}</h3>
+                        <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    </div>
+                    <div class="modal-body">
+                        <form action="{{ route('learner.coaching-time.request') }}" method="POST" id="bookSlotForm">
+                            @csrf
+                            <input type="hidden" name="coaching_timer_id" value="{{ $coachingTimer->id }}">
+                            <input type="hidden" name="editor_time_slot_id" value="">
+                            <textarea name="help_with" cols="30" rows="10" class="form-control"></textarea>
+                            <div class="text-right mt-4">
+                                <button type="submit" class="btn btn-success">{{ trans('site.front.submit') }}</button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    @endif
 </div>
 @endsection
 


### PR DESCRIPTION
## Summary
- prevent race condition by locking slot creation in transaction
- hide help-with modal when no coaching timer is selected

## Testing
- `composer install --no-interaction` (fails: connect tunnel failed 403)
- `vendor/bin/phpunit` (fails: No such file or directory)
- `npm test` (fails: Missing script "test")
- `php -l app/Http/Controllers/Frontend/LearnerController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c244e741708325a220d570e843477e