### PR TITLE
Display helps_with in slot details modal

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -52,9 +52,10 @@ class CoachingTimeController extends Controller
                 $event['borderColor'] = '#28a745';
                 $event['textColor'] = '#ffffff';
                 $event['extendedProps'] = [
-                    'booked'   => true,
-                    'student'  => $accepted->manuscript->user->full_name ?? null,
-                    'duration' => $slot->duration,
+                    'booked'      => true,
+                    'student'     => $accepted->manuscript->user->full_name ?? null,
+                    'duration'    => $slot->duration,
+                    'helps_with'  => $accepted->manuscript->help_with,
                 ];
             }
 

--- a/resources/views/editor/coaching-time/calendar.blade.php
+++ b/resources/views/editor/coaching-time/calendar.blade.php
@@ -34,6 +34,8 @@
                 <p><strong>Start:</strong> <span id="slotStart"></span></p>
                 <p><strong>End:</strong> <span id="slotEnd"></span></p>
                 <p><strong>Duration:</strong> <span id="slotDuration"></span></p>
+                <p><strong>Helps with:</strong></p>
+                <pre id="slotHelpsWith"></pre>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
@@ -196,6 +198,7 @@
             document.getElementById('slotStart').textContent = start.toLocaleString('no-NO', fmt);
             document.getElementById('slotEnd').textContent = end.toLocaleString('no-NO', fmt);
             document.getElementById('slotDuration').textContent = (event.extendedProps.duration || ((end - start)/60000)) + ' min';
+            document.getElementById('slotHelpsWith').textContent = event.extendedProps.helps_with || '';
 
             $('#slotDetailsModal').modal('show');
         }


### PR DESCRIPTION
## Summary
- show help request text in slot details modal using a pre block
- include helps_with field in time slot event data

## Testing
- `composer install` *(fails: CONNECT tunnel failed, requires GitHub credentials)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c286cafcc48325a42aab65f8d6c90d