### PR TITLE
Display accepted coaching bookings

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -17,11 +17,19 @@ class CoachingTimeController extends Controller
     {
         $requests = CoachingTimeRequest::whereHas('slot', function ($q) {
             $q->where('editor_id', Auth::id());
-        })->where('status', 'pending')
+        })
+            ->where('status', 'pending')
             ->with(['manuscript.user', 'slot'])
             ->get();
 
-        return view('editor.coaching-time.index', compact('requests'));
+        $bookings = CoachingTimeRequest::whereHas('slot', function ($q) {
+            $q->where('editor_id', Auth::id());
+        })
+            ->where('status', 'accepted')
+            ->with(['manuscript.user', 'slot'])
+            ->get();
+
+        return view('editor.coaching-time.index', compact('requests', 'bookings'));
     }
 
     public function calendar()

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -124,13 +124,17 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr>
-                                    <td>14:00</td>
-                                    <td>Kristine S. Heningsen</td>
-                                    <td>60 min</td>
-                                    <td>Utfordring</td>
-                                    <td><a href="#" class="btn btn-default btn-xs">Beskrivelse</a></td>
-                                </tr>
+                                @forelse($bookings as $booking)
+                                    <tr>
+                                        <td class="slot-time" data-time="{{ \Carbon\Carbon::parse($booking->slot->date.' '.$booking->slot->start_time, 'UTC')->toIso8601String() }}"></td>
+                                        <td>{{ $booking->manuscript->user->full_name }}</td>
+                                        <td>{{ $booking->slot->duration }} min</td>
+                                        <td>{{ $booking->manuscript->help_with }}</td>
+                                        <td></td>
+                                    </tr>
+                                @empty
+                                    <tr><td colspan="5">Ingen bookinger.</td></tr>
+                                @endforelse
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
## Summary
- show editor's accepted coaching bookings in Timeplan table
- fetch accepted booking requests in controller

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed for package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68c38aea87908325ad503136a4b3407b