### PR TITLE
Hide past or completed coaching sessions

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -26,8 +26,19 @@ class CoachingTimeController extends Controller
             $q->where('editor_id', Auth::id());
         })
             ->where('status', 'accepted')
+            ->whereHas('manuscript', function ($q) {
+                $q->where('status', 0);
+            })
             ->with(['manuscript.user', 'slot'])
             ->get()
+            ->filter(function ($booking) {
+                $slotDateTime = Carbon::parse(
+                    $booking->slot->date . ' ' . $booking->slot->start_time,
+                    'UTC'
+                );
+
+                return $slotDateTime->greaterThanOrEqualTo(Carbon::now('UTC'));
+            })
             ->sortBy(function ($booking) {
                 return $booking->slot->date . ' ' . $booking->slot->start_time;
             });


### PR DESCRIPTION
## Summary
- Filter editor schedule bookings to exclude past sessions and those with non-zero coaching-time status

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68c77f6f0ab08325bb93305dfb213b07