### PR TITLE
fix: correct booking count for editors

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Editor;
 
 use AdminHelpers;
 use App\CoachingTimeRequest;
+use App\CoachingTimerManuscript;
 use App\EditorTimeSlot;
 use App\Http\Controllers\Controller;
 use Auth;
@@ -27,7 +28,7 @@ class CoachingTimeController extends Controller
         })
             ->where('status', 'accepted')
             ->whereHas('manuscript', function ($q) {
-                $q->where('status', 0);
+                $q->where('status', '!=', CoachingTimerManuscript::STATUS_FINISHED);
             })
             ->with(['manuscript.user', 'slot'])
             ->get()

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -52,7 +52,7 @@
             <div class="col-sm-3">
                 <div class="stats-card">
                     <p>Mine Forfatter-studenter</p>
-                    <h2>3</h2>
+                    <h2>{{ $bookings->count() }}</h2>
                 </div>
             </div>
             <div class="col-sm-3">


### PR DESCRIPTION
## Summary
- filter out finished coaching sessions when loading bookings for editors
- show dynamic count of upcoming bookings in coaching time dashboard

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7889afbfc8325a0aaabfdee1e43ad