### PR TITLE
feat: show weekly coaching time stats for editors

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -44,9 +44,19 @@ class CoachingTimeController extends Controller
                 return $booking->slot->date . ' ' . $booking->slot->start_time;
             });
 
+        $bookingsThisWeek = $bookings->filter(function ($booking) {
+            $dt = Carbon::parse(
+                $booking->slot->date . ' ' . $booking->slot->start_time,
+                'UTC'
+            )->setTimezone(config('app.timezone'));
+
+            return $dt->isSameWeek(Carbon::now(config('app.timezone')));
+        })->count();
+
         return view('editor.coaching-time.index', [
-            'requests' => $requests,
-            'bookings' => $bookings,
+            'requests'       => $requests,
+            'bookings'       => $bookings,
+            'bookingsThisWeek' => $bookingsThisWeek,
         ]);
     }
 

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -58,7 +58,7 @@
             <div class="col-sm-3">
                 <div class="stats-card">
                     <p>Denne Uken</p>
-                    <h2>8</h2>
+                    <h2>{{ $bookingsThisWeek }}</h2>
                 </div>
             </div>
             <div class="col-sm-3">


### PR DESCRIPTION
## Summary
- count upcoming coaching sessions scheduled for the current week
- display weekly coaching session count in editor dashboard

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, GitHub token required)*

------
https://chatgpt.com/codex/tasks/task_e_68c78ad2a6588325b09e3bf18cbc6006