### PR TITLE
Display available slot count in editor dashboard

### DIFF
--- a/app/Http/Controllers/Editor/CoachingTimeController.php
+++ b/app/Http/Controllers/Editor/CoachingTimeController.php
@@ -53,10 +53,26 @@ class CoachingTimeController extends Controller
             return $dt->isSameWeek(Carbon::now(config('app.timezone')));
         })->count();
 
+        $availableSlots = EditorTimeSlot::where('editor_id', Auth::id())
+            ->whereDoesntHave('requests', function ($q) {
+                $q->where('status', 'accepted');
+            })
+            ->get()
+            ->filter(function ($slot) {
+                $slotDateTime = Carbon::parse(
+                    $slot->date . ' ' . $slot->start_time,
+                    'UTC'
+                );
+
+                return $slotDateTime->greaterThanOrEqualTo(Carbon::now('UTC'));
+            })
+            ->count();
+
         return view('editor.coaching-time.index', [
             'requests'       => $requests,
             'bookings'       => $bookings,
             'bookingsThisWeek' => $bookingsThisWeek,
+            'availableSlots'  => $availableSlots,
         ]);
     }
 

--- a/resources/views/editor/coaching-time/index.blade.php
+++ b/resources/views/editor/coaching-time/index.blade.php
@@ -64,7 +64,7 @@
             <div class="col-sm-4">
                 <div class="stats-card">
                     <p>Ledige Slots</p>
-                    <h2>15</h2>
+                    <h2>{{ $availableSlots }}</h2>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- compute available coaching slots for editor from unbooked future time slots
- show dynamic available slot count in editor coaching-time view

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7abee117c8325a6eaa20202e332a0