### PR TITLE
Exclude past coaching slots from learner dashboard count

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5707,9 +5707,18 @@ class LearnerController extends Controller
             ->whereNull('editor_id')
             ->get();
 
+        $now = Carbon::now('UTC');
+
         $editors = EditorTimeSlot::with('editor')
             ->whereDoesntHave('requests', function ($q) {
                 $q->where('status', 'accepted');
+            })
+            ->where(function ($q) use ($now) {
+                $q->where('date', '>', $now->toDateString())
+                    ->orWhere(function ($q) use ($now) {
+                        $q->where('date', $now->toDateString())
+                            ->where('start_time', '>=', $now->toTimeString());
+                    });
             })
             ->orderBy('date')
             ->orderBy('start_time')


### PR DESCRIPTION
## Summary
- Exclude past editor time slots when computing available slots on learner coaching time dashboard

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c7b2ad6a288325af215bfc2130ff59