### PR TITLE
Display monthly coaching session count

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -5744,11 +5744,21 @@ class LearnerController extends Controller
                 return $session->timeSlot->date . ' ' . $session->timeSlot->start_time;
             });
 
+        $bookedSessionsThisMonth = $bookedSessions->filter(function ($session) {
+            $dt = Carbon::parse(
+                $session->timeSlot->date . ' ' . $session->timeSlot->start_time,
+                'UTC'
+            )->setTimezone(config('app.timezone'));
+
+            return $dt->isSameMonth(Carbon::now(config('app.timezone')));
+        })->count();
+
         return view('frontend.learner.coaching-time', compact(
             'editors',
             'coachingTimers',
             'bookedEditorsCount',
-            'bookedSessions'
+            'bookedSessions',
+            'bookedSessionsThisMonth'
         ));
     }
 

--- a/resources/views/frontend/learner/coaching-time.blade.php
+++ b/resources/views/frontend/learner/coaching-time.blade.php
@@ -130,7 +130,7 @@
             <div class="col-sm-3">
                 <div class="stats-card">
                     <p>Denne Måneden</p>
-                    <h2>-</h2>
+                    <h2>{{ $bookedSessionsThisMonth }}</h2>
                 </div>
             </div>
             <div class="col-sm-3">


### PR DESCRIPTION
## Summary
- calculate number of coaching sessions scheduled for the current month
- show this count in the “Denne Måneden” card on the learner coaching-time page

## Testing
- `php -l app/Http/Controllers/Frontend/LearnerController.php`
- `php -l resources/views/frontend/learner/coaching-time.blade.php`
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ceb0515c8325b0483e8a07f78919