### PR TITLE
Add pay later tab to learner invoices

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -1497,6 +1497,14 @@ class LearnerController extends Controller
         }
 
         $sveaOrders = Auth::user()->orders()->svea()->with('coachingTime')->paginate(10);
+        $payLaterOrders = Auth::user()->orders()
+            ->where([
+                'is_pay_later' => 1,
+                'is_processed' => 1,
+                'is_invoice_sent' => 0,
+                'is_order_withdrawn' => 0,
+            ])
+            ->paginate(10);
         $user = Auth::user();
 
         $orderAttachments = DB::table('course_order_attachments')
@@ -1524,8 +1532,16 @@ class LearnerController extends Controller
         $data = curl_exec($ch);
         $data = json_decode($data);
         $fikenInvoices = $data->_embedded->{'https://fiken.no/api/v1/rel/invoices'};*/
-        return view('frontend.learner.invoice', compact('invoices', 'sveaOrders', 'user',
-            'orderAttachments', 'giftPurchases', 'orderHistory', 'timeRegisters'));
+        return view('frontend.learner.invoice', compact(
+            'invoices',
+            'sveaOrders',
+            'user',
+            'orderAttachments',
+            'giftPurchases',
+            'orderHistory',
+            'timeRegisters',
+            'payLaterOrders'
+        ));
     }
 
     public function invoiceShow($id)

--- a/resources/views/frontend/learner/invoice.blade.php
+++ b/resources/views/frontend/learner/invoice.blade.php
@@ -63,14 +63,18 @@
 
 					@php
 						$tabWithLabel = [
-							[
-								'name' => 'svea',
-								'label' => 'Svea'
-							],
-							[
-								'name' => 'regret-form',
-								'label' => 'Angreskjema'
-							],
+                                                        [
+                                                                'name' => 'svea',
+                                                                'label' => 'Svea'
+                                                        ],
+                                                        [
+                                                                'name' => 'pay-later',
+                                                                'label' => 'Pay later'
+                                                        ],
+                                                        [
+                                                                'name' => 'regret-form',
+                                                                'label' => 'Angreskjema'
+                                                        ],
 							[
 								'name' => 'gift',
 								'label' => 'Gift Purchases'
@@ -172,10 +176,47 @@
 								<div class="float-right">
 									{{ $sveaOrders->appends(request()->except('page'))->links('pagination.short-pagination') }}
 								</div>
-							@elseif( Request::input('tab') == 'regret-form' )
-								<div class="card global-card">
-									<div class="card-body py-0">
-										<table class="table table-global">
+                                                        @elseif( Request::input('tab') == 'pay-later' )
+                                                                <div class="card global-card">
+                                                                        <div class="card-body py-0">
+                                                                                <table class="table table-global">
+                                                                                        <thead>
+                                                                                                <tr>
+                                                                                                        <th>Item</th>
+                                                                                                        <th>Package</th>
+                                                                                                        <th>Payment plan</th>
+                                                                                                        <th>Payment mode</th>
+                                                                                                        <th>Date</th>
+                                                                                                        <th>Total</th>
+                                                                                                </tr>
+                                                                                        </thead>
+                                                                                        <tbody>
+                                                                                                @forelse($payLaterOrders as $order)
+                                                                                                        <tr>
+                                                                                                                <td>{{ $order->item }}</td>
+                                                                                                                <td>{{ $order->packageVariation }}</td>
+                                                                                                                <td>{{ optional($order->paymentPlan)->plan }}</td>
+                                                                                                                <td>{{ optional($order->paymentMode)->mode }}</td>
+                                                                                                                <td>{{ $order->created_at_formatted }}</td>
+                                                                                                                <td>{{ $order->total_formatted }}</td>
+                                                                                                        </tr>
+                                                                                                @empty
+                                                                                                        <tr>
+                                                                                                                <td colspan="6" class="text-center">No pay later orders found.</td>
+                                                                                                        </tr>
+                                                                                                @endforelse
+                                                                                        </tbody>
+                                                                                </table>
+                                                                        </div>
+                                                                </div>
+
+                                                                <div class="float-right">
+                                                                        {{ $payLaterOrders->appends(request()->except('page'))->links('pagination.short-pagination') }}
+                                                                </div>
+                                                        @elseif( Request::input('tab') == 'regret-form' )
+                                                                <div class="card global-card">
+                                                                        <div class="card-body py-0">
+                                                                                <table class="table table-global">
 											<thead>
 											<tr>
 												<th>{{ trans_choice('site.courses', 1) }}</th>


### PR DESCRIPTION
## Summary
- load the learner's pay later orders with the required filters
- add a Pay later tab to the learner invoice page that lists the filtered orders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0fb8bb75c832594d1e50cb4bf47ec