### PR TITLE
Add pay later payment plan management for courses

### DIFF
--- a/app/Course.php
+++ b/app/Course.php
@@ -17,10 +17,14 @@ class Course extends Model
     // completed_date and issue_date is used on downloading certificate
     protected $fillable = ['title', 'description', 'description_simplemde', 'course_image', 'type', 'email',
         'course_plan', 'course_plan_data', 'start_date', 'end_date', 'completed_date', 'issue_date', 'extend_courses',
-        'instructor', 'auto_list_id', 'photographer', 'pay_later_with_application', 'is_free', 'hide_price',
+        'instructor', 'auto_list_id', 'photographer', 'pay_later_with_application', 'payment_plan_ids', 'is_free', 'hide_price',
         'meta_title', 'meta_description', 'meta_image'];
 
     protected $appends = ['is_webinar_pakke'];
+
+    protected $casts = [
+        'payment_plan_ids' => 'array',
+    ];
 
     public function packages(): HasMany
     {

--- a/app/Http/Controllers/Backend/CourseController.php
+++ b/app/Http/Controllers/Backend/CourseController.php
@@ -494,6 +494,41 @@ class CourseController extends Controller
         ]);
     }
 
+    public function togglePaymentPlan(Request $request, Course $course): JsonResponse
+    {
+        $validated = $request->validate([
+            'payment_plan_id' => 'required|exists:payment_plans,id',
+            'is_active' => 'required|boolean',
+        ]);
+
+        $paymentPlanIds = collect($course->payment_plan_ids ?? [])
+            ->map(static fn ($id) => (int) $id)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $paymentPlanId = (int) $validated['payment_plan_id'];
+
+        if ($request->boolean('is_active')) {
+            if (! in_array($paymentPlanId, $paymentPlanIds, true)) {
+                $paymentPlanIds[] = $paymentPlanId;
+            }
+        } else {
+            $paymentPlanIds = array_values(array_filter($paymentPlanIds, static function ($id) use ($paymentPlanId) {
+                return (int) $id !== $paymentPlanId;
+            }));
+        }
+
+        $course->payment_plan_ids = $paymentPlanIds;
+        $course->save();
+
+        return response()->json([
+            'status' => 'success',
+            'payment_plan_ids' => $course->payment_plan_ids ?? [],
+        ]);
+    }
+
     public function sendEmailToLearners($id, Request $request): RedirectResponse
     {
         $course = Course::find($id);

--- a/database/migrations/2024_05_08_000000_add_payment_plan_ids_to_courses_table.php
+++ b/database/migrations/2024_05_08_000000_add_payment_plan_ids_to_courses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->json('payment_plan_ids')->nullable()->after('pay_later_with_application');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('courses', function (Blueprint $table) {
+            $table->dropColumn('payment_plan_ids');
+        });
+    }
+};

--- a/resources/views/backend/course/learners.blade.php
+++ b/resources/views/backend/course/learners.blade.php
@@ -120,14 +120,14 @@
 				</button>
 			@endif
 
-                        <ul class="nav nav-tabs margin-top">
-                                <li class="active"><a href="#learners" data-toggle="tab">Learners</a></li>
-                                <li><a href="#logs" data-toggle="tab">Email Out Log</a></li>
-                                <li><a href="#packages" data-toggle="tab">Packages</a></li>
-                                <li><a href="#payLaterOptions" data-toggle="tab">Pay Later Options</a></li>
-                                @if ($course->is_free)
-                                        <li><a href="#templateTab" data-toggle="tab">Email Reminder Template</a></li>
-                                @endif
+			<ul class="nav nav-tabs margin-top">
+				<li class="active"><a href="#learners" data-toggle="tab">Learners</a></li>
+				<li><a href="#logs" data-toggle="tab">Email Out Log</a></li>
+				<li><a href="#packages" data-toggle="tab">Packages</a></li>
+				<li><a href="#payLaterOptions" data-toggle="tab">Pay Later Options</a></li>
+				@if ($course->is_free)
+						<li><a href="#templateTab" data-toggle="tab">Email Reminder Template</a></li>
+				@endif
 			</ul>
 
 			<div class="tab-content">
@@ -278,95 +278,95 @@
 					</div>
 				</div> <!-- end send email out log -->
 
-                                <div class="tab-pane fade margin-top" id="packages" role="tabpanel">
-                                        <div class="table-responsive">
-                                                <table class="table table-side-bordered table-white">
-                                                        <thead>
-                                                                <tr>
-                                                                        <th>Package</th>
-                                                                        <th>Learners</th>
-                                                                        <th width="350"></th>
-                                                                        <th width="350"></th>
-                                                                </tr>
-                                                        </thead>
-                                                        <tbody>
-                                                                @foreach ($course->packages as $package)
-                                                                        <tr>
-                                                                                <td>
-                                                                                        {{ $package->variation }}
-                                                                                </td>
-                                                                                <td>
-                                                                                        {{ \App\CoursesTaken::where('package_id', $package->id)
-                                                                                        ->where('is_active', true)->count() }}
-                                                                                </td>
-                                                                                <td>
-                                                                                        <button type="submit" data-toggle="modal" data-target="#importLearnersModal"
-                                                                                                        class="btn btn-primary btn-xs pull-right import-learners-btn"
-                                                                                                        data-package="{{ json_encode($package) }}"
-                                                                                                        data-action="{{ route('admin.course.package.import-learners') }}">
-                                                                                                        Import Learners
-                                                                                        </button>
-                                                                                </td>
-                                                                                <td>
-                                                                                        {{-- <button type="submit" data-toggle="modal" data-target="#copyPackageModal"
-                                                                                                        class="btn btn-primary btn-xs pull-right copy-package-btn"
-                                                                                                        data-package="{{ json_encode($package) }}"
-                                                                                                        data-action="{{ route('admin.course.package.copy-package-and-learners') }}">
-                                                                                                        Copy Package
-                                                                                        </button> --}}
+				<div class="tab-pane fade margin-top" id="packages" role="tabpanel">
+					<div class="table-responsive">
+						<table class="table table-side-bordered table-white">
+							<thead>
+								<tr>
+									<th>Package</th>
+									<th>Learners</th>
+									<th width="350"></th>
+									<th width="350"></th>
+								</tr>
+							</thead>
+							<tbody>
+								@foreach ($course->packages as $package)
+									<tr>
+										<td>
+												{{ $package->variation }}
+										</td>
+										<td>
+												{{ \App\CoursesTaken::where('package_id', $package->id)
+												->where('is_active', true)->count() }}
+										</td>
+										<td>
+											<button type="submit" data-toggle="modal" data-target="#importLearnersModal"
+												class="btn btn-primary btn-xs pull-right import-learners-btn"
+												data-package="{{ json_encode($package) }}"
+												data-action="{{ route('admin.course.package.import-learners') }}">
+												Import Learners
+											</button>
+										</td>
+										<td>
+											{{-- <button type="submit" data-toggle="modal" data-target="#copyPackageModal"
+															class="btn btn-primary btn-xs pull-right copy-package-btn"
+															data-package="{{ json_encode($package) }}"
+															data-action="{{ route('admin.course.package.copy-package-and-learners') }}">
+															Copy Package
+											</button> --}}
 
-                                                                                        <button type="submit" data-toggle="modal" data-target="#copyLearnersModal"
-                                                                                                        class="btn btn-primary btn-xs pull-right copy-learners-btn"
-                                                                                                        data-package="{{ json_encode($package) }}"
-                                                                                                        data-action="{{ route('admin.course.package.copy-learners') }}"
-                                                                                                        style="margin-right: 3px">
-                                                                                                        Copy Learners
-                                                                                        </button>
-                                                                                </td>
-                                                                        </tr>
-                                                                @endforeach
-                                                        </tbody>
-                                                </table>
-                                        </div>
-                                </div>
-                                <div class="tab-pane fade margin-top" id="payLaterOptions" role="tabpanel">
-                                        <div class="table-responsive">
-                                                @if ($paymentPlans->count())
-                                                        <table class="table table-side-bordered table-white">
-                                                                <thead>
-                                                                        <tr>
-                                                                                <th>Division</th>
-                                                                                <th>Payment Plan</th>
-                                                                                <th width="200">Active</th>
-                                                                        </tr>
-                                                                </thead>
-                                                                <tbody>
-                                                                        @foreach ($paymentPlans as $paymentPlan)
-                                                                                <tr>
-                                                                                        <td>{{ $paymentPlan->division }}</td>
-                                                                                        <td>{{ $paymentPlan->plan }}</td>
-                                                                                        <td>
-                                                                                                <input type="checkbox"
-                                                                                                       data-toggle="toggle"
-                                                                                                       data-on="Yes"
-                                                                                                       data-off="No"
-                                                                                                       data-size="mini"
-                                                                                                       class="course-payment-plan-toggle"
-                                                                                                       data-payment-plan-id="{{ $paymentPlan->id }}"
-                                                                                                       data-url="{{ route('learner.course.payment-plans.toggle', $course->id) }}"
-                                                                                                       @if ($coursePaymentPlans->contains($paymentPlan->id)) checked @endif>
-                                                                                        </td>
-                                                                                </tr>
-                                                                        @endforeach
-                                                                </tbody>
-                                                        </table>
-                                                @else
-                                                        <p class="text-center">No payment plans available.</p>
-                                                @endif
-                                        </div>
-                                </div>
-                        </div>
-                </div>
+											<button type="submit" data-toggle="modal" data-target="#copyLearnersModal"
+												class="btn btn-primary btn-xs pull-right copy-learners-btn"
+												data-package="{{ json_encode($package) }}"
+												data-action="{{ route('admin.course.package.copy-learners') }}"
+												style="margin-right: 3px">
+												Copy Learners
+											</button>
+										</td>
+									</tr>
+								@endforeach
+							</tbody>
+						</table>
+					</div>
+				</div>
+				<div class="tab-pane fade margin-top" id="payLaterOptions" role="tabpanel">
+					<div class="table-responsive">
+						@if ($paymentPlans->count())
+							<table class="table table-side-bordered table-white">
+								<thead>
+									<tr>
+										<th>Division</th>
+										<th>Payment Plan</th>
+										<th width="200">Active</th>
+									</tr>
+								</thead>
+								<tbody>
+									@foreach ($paymentPlans as $paymentPlan)
+										<tr>
+											<td>{{ $paymentPlan->division }}</td>
+											<td>{{ $paymentPlan->plan }}</td>
+											<td>
+												<input type="checkbox"
+													data-toggle="toggle"
+													data-on="Yes"
+													data-off="No"
+													data-size="mini"
+													class="course-payment-plan-toggle"
+													data-payment-plan-id="{{ $paymentPlan->id }}"
+													data-url="{{ route('learner.course.payment-plans.toggle', $course->id) }}"
+													@if ($coursePaymentPlans->contains($paymentPlan->id)) checked @endif>
+											</td>
+										</tr>
+									@endforeach
+								</tbody>
+							</table>
+							@else
+									<p class="text-center">No payment plans available.</p>
+							@endif
+						</div>
+					</div>
+				</div>
+			</div>
         </div>
 	<div class="clearfix"></div>
 </div>

--- a/resources/views/backend/course/learners.blade.php
+++ b/resources/views/backend/course/learners.blade.php
@@ -59,6 +59,8 @@
 
     $emailOutLog = $course->emailOutLog()->paginate(20);
     $expiryReminder = $course->expiryReminders;
+    $paymentPlans = \App\PaymentPlan::orderBy('division')->orderBy('plan')->get();
+    $coursePaymentPlans = collect($course->payment_plan_ids ?? []);
     ?>
 
 	<div class="col-sm-12 col-md-10 sub-right-content">
@@ -118,13 +120,14 @@
 				</button>
 			@endif
 
-			<ul class="nav nav-tabs margin-top">
-				<li class="active"><a href="#learners" data-toggle="tab">Learners</a></li>
-				<li><a href="#logs" data-toggle="tab">Email Out Log</a></li>
-				<li><a href="#packages" data-toggle="tab">Packages</a></li>
-				@if ($course->is_free)
-					<li><a href="#templateTab" data-toggle="tab">Email Reminder Template</a></li>
-				@endif
+                        <ul class="nav nav-tabs margin-top">
+                                <li class="active"><a href="#learners" data-toggle="tab">Learners</a></li>
+                                <li><a href="#logs" data-toggle="tab">Email Out Log</a></li>
+                                <li><a href="#packages" data-toggle="tab">Packages</a></li>
+                                <li><a href="#payLaterOptions" data-toggle="tab">Pay Later Options</a></li>
+                                @if ($course->is_free)
+                                        <li><a href="#templateTab" data-toggle="tab">Email Reminder Template</a></li>
+                                @endif
 			</ul>
 
 			<div class="tab-content">
@@ -275,60 +278,96 @@
 					</div>
 				</div> <!-- end send email out log -->
 
-				<div class="tab-pane fade margin-top" id="packages" role="tabpanel">
-					<div class="table-responsive">
-						<table class="table table-side-bordered table-white">
-							<thead>
-								<tr>
-									<th>Package</th>
-									<th>Learners</th>
-									<th width="350"></th>
-									<th width="350"></th>
-								</tr>
-							</thead>
-							<tbody>
-								@foreach ($course->packages as $package)
-									<tr>
-										<td>
-											{{ $package->variation }}
-										</td>
-										<td>
-											{{ \App\CoursesTaken::where('package_id', $package->id)
-											->where('is_active', true)->count() }}
-										</td>
-										<td>
-											<button type="submit" data-toggle="modal" data-target="#importLearnersModal" 
-													class="btn btn-primary btn-xs pull-right import-learners-btn"
-													data-package="{{ json_encode($package) }}" 
-													data-action="{{ route('admin.course.package.import-learners') }}">
-													Import Learners
-											</button>
-										</td>
-										<td>
-											{{-- <button type="submit" data-toggle="modal" data-target="#copyPackageModal" 
-													class="btn btn-primary btn-xs pull-right copy-package-btn"
-													data-package="{{ json_encode($package) }}"
-													data-action="{{ route('admin.course.package.copy-package-and-learners') }}">
-													Copy Package
-											</button> --}}
+                                <div class="tab-pane fade margin-top" id="packages" role="tabpanel">
+                                        <div class="table-responsive">
+                                                <table class="table table-side-bordered table-white">
+                                                        <thead>
+                                                                <tr>
+                                                                        <th>Package</th>
+                                                                        <th>Learners</th>
+                                                                        <th width="350"></th>
+                                                                        <th width="350"></th>
+                                                                </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                                @foreach ($course->packages as $package)
+                                                                        <tr>
+                                                                                <td>
+                                                                                        {{ $package->variation }}
+                                                                                </td>
+                                                                                <td>
+                                                                                        {{ \App\CoursesTaken::where('package_id', $package->id)
+                                                                                        ->where('is_active', true)->count() }}
+                                                                                </td>
+                                                                                <td>
+                                                                                        <button type="submit" data-toggle="modal" data-target="#importLearnersModal"
+                                                                                                        class="btn btn-primary btn-xs pull-right import-learners-btn"
+                                                                                                        data-package="{{ json_encode($package) }}"
+                                                                                                        data-action="{{ route('admin.course.package.import-learners') }}">
+                                                                                                        Import Learners
+                                                                                        </button>
+                                                                                </td>
+                                                                                <td>
+                                                                                        {{-- <button type="submit" data-toggle="modal" data-target="#copyPackageModal"
+                                                                                                        class="btn btn-primary btn-xs pull-right copy-package-btn"
+                                                                                                        data-package="{{ json_encode($package) }}"
+                                                                                                        data-action="{{ route('admin.course.package.copy-package-and-learners') }}">
+                                                                                                        Copy Package
+                                                                                        </button> --}}
 
-											<button type="submit" data-toggle="modal" data-target="#copyLearnersModal" 
-													class="btn btn-primary btn-xs pull-right copy-learners-btn"
-													data-package="{{ json_encode($package) }}" 
-													data-action="{{ route('admin.course.package.copy-learners') }}"
-													style="margin-right: 3px">
-													Copy Learners
-											</button>
-										</td>
-									</tr>
-								@endforeach
-							</tbody>
-						</table>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+                                                                                        <button type="submit" data-toggle="modal" data-target="#copyLearnersModal"
+                                                                                                        class="btn btn-primary btn-xs pull-right copy-learners-btn"
+                                                                                                        data-package="{{ json_encode($package) }}"
+                                                                                                        data-action="{{ route('admin.course.package.copy-learners') }}"
+                                                                                                        style="margin-right: 3px">
+                                                                                                        Copy Learners
+                                                                                        </button>
+                                                                                </td>
+                                                                        </tr>
+                                                                @endforeach
+                                                        </tbody>
+                                                </table>
+                                        </div>
+                                </div>
+                                <div class="tab-pane fade margin-top" id="payLaterOptions" role="tabpanel">
+                                        <div class="table-responsive">
+                                                @if ($paymentPlans->count())
+                                                        <table class="table table-side-bordered table-white">
+                                                                <thead>
+                                                                        <tr>
+                                                                                <th>Division</th>
+                                                                                <th>Payment Plan</th>
+                                                                                <th width="200">Active</th>
+                                                                        </tr>
+                                                                </thead>
+                                                                <tbody>
+                                                                        @foreach ($paymentPlans as $paymentPlan)
+                                                                                <tr>
+                                                                                        <td>{{ $paymentPlan->division }}</td>
+                                                                                        <td>{{ $paymentPlan->plan }}</td>
+                                                                                        <td>
+                                                                                                <input type="checkbox"
+                                                                                                       data-toggle="toggle"
+                                                                                                       data-on="Yes"
+                                                                                                       data-off="No"
+                                                                                                       data-size="mini"
+                                                                                                       class="course-payment-plan-toggle"
+                                                                                                       data-payment-plan-id="{{ $paymentPlan->id }}"
+                                                                                                       data-url="{{ route('learner.course.payment-plans.toggle', $course->id) }}"
+                                                                                                       @if ($coursePaymentPlans->contains($paymentPlan->id)) checked @endif>
+                                                                                        </td>
+                                                                                </tr>
+                                                                        @endforeach
+                                                                </tbody>
+                                                        </table>
+                                                @else
+                                                        <p class="text-center">No payment plans available.</p>
+                                                @endif
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
 	<div class="clearfix"></div>
 </div>
 
@@ -974,7 +1013,7 @@
             });
         });
 
-		$(".facebook-group-toggle").change(function(){
+        $(".facebook-group-toggle").change(function(){
             let learner_id = $(this).attr('data-id');
             let is_checked = $(this).prop('checked');
             let check_val = is_checked ? 1 : 0;
@@ -988,9 +1027,27 @@
             });
         });
 
-		$(".btn-remove-learner").click(function() {
-			$("[name=is_permanent]").prop('checked', false).trigger('change');
-		})
+        $(".course-payment-plan-toggle").change(function(){
+            let toggle = $(this);
+            let isChecked = toggle.prop('checked');
+            $.ajax({
+                type:'POST',
+                url: toggle.data('url'),
+                headers: {'X-CSRF-TOKEN': '{{ csrf_token() }}' },
+                data: {
+                    payment_plan_id: toggle.data('payment-plan-id'),
+                    is_active: isChecked ? 1 : 0
+                },
+                error: function(){
+                    toggle.bootstrapToggle(isChecked ? 'off' : 'on');
+                    alert('Unable to update payment plan. Please try again.');
+                }
+            });
+        });
+
+                $(".btn-remove-learner").click(function() {
+                        $("[name=is_permanent]").prop('checked', false).trigger('change');
+                })
 
 		$(".btn-remove-learner-permanently").click(function() {
 			var form = $('#removeLearnerModal form');

--- a/routes/web.php
+++ b/routes/web.php
@@ -852,6 +852,7 @@ Route::domain($admin)->group(function () {
         Route::get('/course/{id}/learner-list-excel/{type?}', [Backend\CourseController::class, 'learnerListExcel'])->name('learner.course.learner-list-excel'); // Add Learner To Course
         Route::get('/course/{id}/learner-active-list-excel', [Backend\CourseController::class, 'learnerActiveListExcel'])->name('learner.course.learner-active-list-excel'); // Add Learner To Course
         Route::get('/course/{id}/pay-later/export', [Backend\CourseController::class, 'exportPayLaterLearners'])->name('learner.course.pay-later'); // Add Learner To Course
+        Route::post('/course/{course}/payment-plans/toggle', [Backend\CourseController::class, 'togglePaymentPlan'])->name('learner.course.payment-plans.toggle');
         Route::post('/course/{id}/expirationReminder', [Backend\CourseController::class, 'expirationReminder'])->name('admin.course.expiration-reminder');
         Route::post('/course/{id}/add-learners-to-webinars', [Backend\CourseController::class, 'addLearnersToWebinars'])->name('admin.course.add-learners-to-webinars');
         Route::post('/course/{id}/certificate-dates', [Backend\CourseController::class, 'updateCertificateDates'])->name('admin.course.update-certificate-dates');


### PR DESCRIPTION
## Summary
- add a JSON column to courses for storing selected payment plan IDs and expose it on the model
- allow administrators to toggle course payment plans through a dedicated backend endpoint
- surface a new "Pay Later Options" tab on the learners page that lists payment plans with toggle controls and supporting JavaScript

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68d357e96d30832597f3cbb6f3802f42