### PR TITLE
Add monthly sales modal for learner sales chart

### DIFF
--- a/app/Http/Controllers/Frontend/LearnerController.php
+++ b/app/Http/Controllers/Frontend/LearnerController.php
@@ -2474,6 +2474,45 @@ class LearnerController extends Controller
         return $data;
     }
 
+    public function bookSaleMonthlyDetails($year, $month): JsonResponse
+    {
+        $year = (int) $year;
+        $month = (int) $month;
+
+        if ($month < 1 || $month > 12) {
+            return response()->json([]);
+        }
+
+        $learner = Auth::user();
+        $standardProject = FrontendHelpers::getLearnerStandardProject($learner->id);
+
+        if (! $standardProject) {
+            return response()->json([]);
+        }
+
+        $sales = ProjectBookSale::select('project_book_sales.*')
+            ->leftJoin('project_books', 'project_book_sales.project_book_id', '=', 'project_books.id')
+            ->where('project_books.project_id', $standardProject->id)
+            ->where('project_books.user_id', $learner->id)
+            ->whereYear('project_book_sales.date', $year)
+            ->whereMonth('project_book_sales.date', $month)
+            ->orderBy('project_book_sales.date', 'desc')
+            ->get()
+            ->map(function (ProjectBookSale $sale) {
+                return [
+                    'date' => $sale->date ? Carbon::parse($sale->date)->format('Y-m-d') : null,
+                    'customer_name' => $sale->customer_name,
+                    'quantity' => (int) $sale->quantity,
+                    'price' => $sale->price_formatted,
+                    'discount' => $sale->discount_formatted,
+                    'amount' => $sale->total_amount_formatted,
+                ];
+            })
+            ->values();
+
+        return response()->json($sales);
+    }
+
     public function saveForSaleBooks(Request $request): RedirectResponse
     {
         $request->validate([

--- a/resources/lang/en/site.php
+++ b/resources/lang/en/site.php
@@ -1437,4 +1437,6 @@ kvittering.',
         'upload-your-book' => 'Du kan også laste opp boken din så regner kalkulatoren hva prisen blir.',
         'services-included' => 'Services Included',
     ],
+    'monthly-sales-empty' => 'No sales available for this month.',
+    'monthly-sales-error' => 'Unable to load sales for the selected month. Please try again later.',
 ];

--- a/resources/lang/no/site.php
+++ b/resources/lang/no/site.php
@@ -1638,4 +1638,6 @@ Rektor Kristine',
     'contract' => [
         'signature-note' => 'Signatures will appear here once this document is signed.',
     ],
+    'monthly-sales-empty' => 'Ingen salg registrert for denne måneden.',
+    'monthly-sales-error' => 'Klarte ikke å laste inn salg for den valgte måneden. Prøv igjen senere.',
 ];

--- a/resources/views/frontend/learner/self-publishing/sales.blade.php
+++ b/resources/views/frontend/learner/self-publishing/sales.blade.php
@@ -308,6 +308,48 @@
         </div>
     </div>
 
+    <div id="monthlySalesModal" class="modal fade" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">
+                        {{ trans('site.author-portal.book-sales') }}
+                        <small class="text-muted d-block selected-month-year"></small>
+                    </h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{{ trans('site.close') }}">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div id="monthlySalesLoader" class="text-center py-3 d-none">
+                        <i class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></i>
+                    </div>
+                    <div id="monthlySalesErrorState" class="alert alert-danger d-none">
+                        {{ trans('site.monthly-sales-error') }}
+                    </div>
+                    <div id="monthlySalesEmptyState" class="alert alert-info d-none">
+                        {{ trans('site.monthly-sales-empty') }}
+                    </div>
+                    <div class="table-responsive">
+                        <table class="table table-striped" id="monthlySalesTable">
+                            <thead>
+                                <tr>
+                                    <th>{{ trans('site.date') }}</th>
+                                    <th>{{ trans('site.author-portal.customer-name') }}</th>
+                                    <th>{{ trans('site.order-history.quantity') }}</th>
+                                    <th>{{ trans('site.price') }}</th>
+                                    <th>{{ trans('site.front.discount') }}</th>
+                                    <th>{{ trans('site.amount') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <div id="booksForSaleModal" class="modal fade" role="dialog">
         <div class="modal-dialog modal-md">
             <div class="modal-content">
@@ -392,9 +434,24 @@
 
         $(document).ready(function() {
             let ctx = $("#chart-line");
+            const yearSelector = $("#yearSelector");
             const monthAbbreviations = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
             ];
+            const monthlySalesModal = $("#monthlySalesModal");
+            const monthlySalesTableBody = $("#monthlySalesTable tbody");
+            const monthlySalesEmptyState = $("#monthlySalesEmptyState");
+            const monthlySalesErrorState = $("#monthlySalesErrorState");
+            const monthlySalesLoader = $("#monthlySalesLoader");
+            const monthlySalesTitle = monthlySalesModal.find('.selected-month-year');
+            const monthlySalesEndpoint = '/account/book-sale/monthly-details/';
+
+            let year = "{{ request()->get('year') }}";
+            const currentYear = new Date().getFullYear();
+
+            if (!year) {
+                year = currentYear;
+            }
 
             const options = {
                 scales: {
@@ -425,6 +482,17 @@
                             return i18n.site['author-portal-menu'].sales + ': ' + currencyFormatter.format(tooltipItems.yLabel);
                         }
                     }
+                },
+                onClick: function(evt, elements) {
+                    if (! elements.length) {
+                        return;
+                    }
+
+                    const element = elements[0];
+                    const elementIndex = typeof element._index !== 'undefined' ? element._index : element.index;
+                    const selectedYearValue = yearSelector.length ? yearSelector.val() : year;
+
+                    showMonthlySalesModal(selectedYearValue, elementIndex);
                 }
             };
 
@@ -443,15 +511,51 @@
                 options: options
             });
 
-            let year = "{{ request()->get('year') }}";
-            const currentYear = new Date().getFullYear();
-            
-            if (!year) {
-                year = currentYear;
-            }
-
             // get the chart data
             ajax_chart(myLineChart, '/account/book-sale/list-by-month/' + year);
+
+            function showMonthlySalesModal(selectedYearValue, monthIndex) {
+                if (monthIndex < 0 || monthIndex >= monthAbbreviations.length) {
+                    return;
+                }
+
+                const normalizedYear = parseInt(selectedYearValue, 10) || year || currentYear;
+                const monthNumber = monthIndex + 1;
+
+                monthlySalesTitle.text(monthAbbreviations[monthIndex] + ' ' + normalizedYear);
+                monthlySalesTableBody.empty();
+                monthlySalesEmptyState.addClass('d-none');
+                monthlySalesErrorState.addClass('d-none');
+                monthlySalesLoader.removeClass('d-none');
+
+                monthlySalesModal.modal('show');
+
+                $.getJSON(monthlySalesEndpoint + normalizedYear + '/' + monthNumber)
+                    .done(function(records) {
+                        if (Array.isArray(records) && records.length) {
+                            records.forEach(function(record) {
+                                const row = $('<tr/>');
+                                row.append($('<td/>').text(record.date || ''));
+                                row.append($('<td/>').text(record.customer_name || ''));
+                                row.append($('<td/>').text(
+                                    record.quantity !== null && record.quantity !== undefined ? record.quantity : ''
+                                ));
+                                row.append($('<td/>').text(record.price || ''));
+                                row.append($('<td/>').text(record.discount || ''));
+                                row.append($('<td/>').text(record.amount || ''));
+                                monthlySalesTableBody.append(row);
+                            });
+                        } else {
+                            monthlySalesEmptyState.removeClass('d-none');
+                        }
+                    })
+                    .fail(function() {
+                        monthlySalesErrorState.removeClass('d-none');
+                    })
+                    .always(function() {
+                        monthlySalesLoader.addClass('d-none');
+                    });
+            }
 
             $(".booksForSaleBtn").click(function() {
                 let record = $(this).data('record');

--- a/routes/web.php
+++ b/routes/web.php
@@ -336,6 +336,8 @@ Route::domain($front)->group(function () {
         Route::get('/book-sale', [Frontend\LearnerController::class, 'bookSale'])->name('learner.book-sale');
         Route::get('/book-for-sale/{id}', [Frontend\LearnerController::class, 'bookForSale'])->name('learner.book-for-sale');
         Route::get('/book-sale/list-by-month/{year}', [Frontend\LearnerController::class, 'bookSaleByMonth']);
+        Route::get('/book-sale/monthly-details/{year}/{month}',
+            [Frontend\LearnerController::class, 'bookSaleMonthlyDetails']);
         Route::get('project/{project_id}/registration/{registration_id}/storage-cost/{year}/export', [Frontend\LearnerController::class, 'exportStorageCost'])
             ->name('learner.project.storage-cost.export');
         Route::post('/for-sale-books/save', [Frontend\LearnerController::class, 'saveForSaleBooks'])->name('learner.save-for-sale-books');


### PR DESCRIPTION
## Summary
- add an endpoint that returns monthly sales details for the learner's standard project and expose it via routing
- enhance the sales chart so clicking a month opens a modal with the monthly sales breakdown and localized messaging
- add translation strings used by the new modal states

## Testing
- php -l app/Http/Controllers/Frontend/LearnerController.php

------
https://chatgpt.com/codex/tasks/task_e_68d4f10b56c08325bc8ec29bb4d0d0f9